### PR TITLE
setup: Remove core python dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,9 +34,6 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     aiohttp
-    asyncio
-    configparser
-    dataclasses
     rich
 include_package_data=True
 


### PR DESCRIPTION
The asyncio, configparser, and dataclasses modules are distributed as
part of python since at least python 3.7. Since revup requires
python3.8 or above, we can remove these dependencies from the
setup.cfg.

Signed-off-by: Brian Kubisiak <brian@kubisiak.com>