### PR TITLE
main: Fix console entry point in setup.cfg

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -5,12 +5,18 @@ import sys
 from revup.revup import main
 from revup.types import RevupConflictException, RevupUsageException
 
-try:
-    # Exit code of 1 is reserved for exception-based exits
-    sys.exit(asyncio.run(main()))
-except RevupUsageException as e:
-    logging.error(str(e))
-    sys.exit(2)
-except RevupConflictException as e:
-    logging.error(str(e))
-    sys.exit(3)
+
+def _main() -> None:
+    try:
+        # Exit code of 1 is reserved for exception-based exits
+        sys.exit(asyncio.run(main()))
+    except RevupUsageException as e:
+        logging.error(str(e))
+        sys.exit(2)
+    except RevupConflictException as e:
+        logging.error(str(e))
+        sys.exit(3)
+
+
+if __name__ == "__main__":
+    _main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ where = .
 
 [options.entry_points]
 console_scripts =
-    revup = revup:__main__
+    revup = revup.__main__:_main
 
 [mypy]
 python_version = 3.8


### PR DESCRIPTION
The setuptools module requires that the entrypoint is specified as
'module.submodule:function' and newer versions of setuptools will
break if 'module:submodule' is provided instead. Modify revup's
entrypoint by adding a wrapper _main() function and point at this
instead.

This also fixes importing __main__.py without running it, which can
happen in some linting utilities.

Signed-off-by: Brian Kubisiak <brian@kubisiak.com>