### PR TITLE
Throw an error if using Relative across forks

### DIFF
--- a/docs/revup.md
+++ b/docs/revup.md
@@ -49,6 +49,9 @@ that should be used to push branches to. The pull request will be created
 using the branch from this fork. If empty, remote-name is used for both
 pushing and creating the pull request.
 
+Github does not allow base branches of pull requests to be in a different
+fork, so Relative and Relative-Branch cannot be used across forks.
+
 **--editor**
 : The user's preferred editor, used for various message and file
 editing. If not set, value is taken first from "git config core.editor"

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -469,6 +469,17 @@ class TopicStack:
                         )
                         relative_topic = ""
 
+            if (
+                self.repo_info
+                and self.fork_info
+                and self.fork_info.owner != self.repo_info.owner
+                and (relative_topic or len(topic.tags[TAG_RELATIVE_BRANCH]) > 1)
+            ):
+                raise RevupUsageException(
+                    "Can't use 'Relative' or 'Relative-Branch' across forks due to github"
+                    " limitations!"
+                )
+
             if relative_topic:
                 topic.relative_topic = self.topics[relative_topic]
                 if len(topic.tags[TAG_BRANCH]) == 0:


### PR DESCRIPTION
Github's review model does not allow the base branch
to live in another fork, making it impossible to use
the relative review model. Disable it with a clear
warning.

Reviewers: greg-b, brian-k