### PR TITLE
Handle Relative across forks

### DIFF
--- a/docs/revup.md
+++ b/docs/revup.md
@@ -49,6 +49,10 @@ that should be used to push branches to. The pull request will be created
 using the branch from this fork. If empty, remote-name is used for both
 pushing and creating the pull request.
 
+Github does not allow base branches of pull requests to be in a different
+fork, so reviews with a Relative: label will be deferred until its base
+merges. Relative-Branch cannot be used across forks.
+
 **--editor**
 : The user's preferred editor, used for various message and file
 editing. If not set, value is taken first from "git config core.editor"

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -469,6 +469,19 @@ class TopicStack:
                         )
                         relative_topic = ""
 
+            if self.repo_info and self.fork_info and self.fork_info.owner != self.repo_info.owner:
+                if len(topic.tags[TAG_RELATIVE_BRANCH]) > 1:
+                    raise RevupUsageException(
+                        "Can't use 'Relative-Branch' across forks due to github limitations!"
+                    )
+                if relative_topic:
+                    logging.warning(
+                        f"Skipping topic '{name}' since github does not allow relative reviews"
+                        f" across forks. It will be uploaded when '{relative_topic}' merges."
+                    )
+                    del self.topics[name]
+                    continue
+
             if relative_topic:
                 topic.relative_topic = self.topics[relative_topic]
                 if len(topic.tags[TAG_BRANCH]) == 0:


### PR DESCRIPTION
Github's review model does not allow the base branch
to live in another fork, making it impossible to use
the relative review model.

Throw an error if using Relative-Branch, and skip topics
that are relative until the base is merged.

Reviewers: greg-b, brian-k