### PR TITLE
Fix mistaken 'continue' in rebase logic

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -713,7 +713,7 @@ class TopicStack:
                         # TODO: We can do more optimization by reusing the remote trees.
                         # We wouldn't benefit as much from skipping the push, but we'd save time
                         # on creating commits.
-                        continue
+                        pass
 
             if review.is_pure_rebase and review.pr_info is not None:
                 # For a relative series of reviews, revup will only ever upload them directly


### PR DESCRIPTION
Somehow I confused 'continue' for 'pass'.

This was causing the push marking loop logic
to get totally skipped, resulting in crashes
and cases where commit ids could not be found
in depending reviews.

Topic: mistake
Reviewers: brian-k, greg
Fixes: #6