### PR TITLE
Fix warnings and errors with setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,13 @@ clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf .mypy_cache
 
-package: man
-	$(PYTHON) -m build --outdir $(BUILD_DIR)
-
 REVUP_VERSION:=$(shell $(PYTHON) revup/__init__.py)
 REVUP_DATE ?= Apr 21, 2021
 REVUP_HEADER=---\ntitle: TITLE\nsection: 1\nheader: Revup Manual\nfooter: revup VERSION\ndate: DATE\n---\n
+REVUP_VERSION_HASH?=${shell git rev-parse --short v$(REVUP_VERSION) || echo main}
+
+package: man
+	REVUP_VERSION_HASH=$(REVUP_VERSION_HASH) $(PYTHON) -m build --outdir $(BUILD_DIR)
 
 install:
 	$(PYTHON) -m pip install build/revup-$(REVUP_VERSION)-py3-none-any.whl --force-reinstall

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,8 @@ author_email = jerry@skydio.com
 description = Revolutionary github tools. Effortlessly create multiple branches and pull requests.
 keywords = github python git workflow version-control python3 developer-tools code-review pull-requests developers developer-productivity stacked-diffs
 license = MIT
-license_file = LICENSE
+license_files =
+    LICENSE
 long_description_content_type = text/markdown
 url = https://github.com/skydio/revup
 project_urls =
@@ -32,8 +33,9 @@ classifiers =
 
 [options]
 package_dir =
-  revup = revup
-packages = find:
+     = .
+packages =
+    revup
 python_requires = >=3.8
 install_requires =
     aiohttp
@@ -59,7 +61,7 @@ dev =
 where = .
 
 [options.package_data]
-revup = *.1.gz
+revup = man1/*.1.gz
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,8 @@
+import os
 import re
-import subprocess
 from pathlib import Path
 
 from setuptools import setup
-
-# Populates the __version__ variable
-with open("revup/__init__.py") as f:
-    exec(f.read())
-
-
-def tag_rev() -> str:
-    """
-    Get the git sha of the current version from the tag
-    """
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--short", f"v{__version__}"],
-            check=True,
-            text=True,
-            stdout=subprocess.PIPE,
-        )
-        return result.stdout.strip()
-    except subprocess.CalledProcessError:
-        return "main"
 
 
 def fixed_readme() -> str:
@@ -39,10 +19,13 @@ def fixed_readme() -> str:
         flags=re.MULTILINE | re.DOTALL,
     )
 
+    # Git hash of the commit tagged with the current version. Set by Makefile.
+    revup_version_hash = os.environ.get("REVUP_VERSION_HASH", "main")
+
     # Replace relative links with absolute, so images appear correctly on PyPI
     readme = readme.replace(
         "docs/images/",
-        f"https://raw.githubusercontent.com/skydio/revup/{tag_rev()}/docs/images/",
+        f"https://raw.githubusercontent.com/skydio/revup/{revup_version_hash}/docs/images/",
     )
 
     return readme


### PR DESCRIPTION
Fix man files not being included.

Fix deprecation warnings related to licenses field and
packages.

Fix git revision not being found correctly because setup.py
is executed in a tmp directory. Instead find the revision
in the makefile and pass it into setup.

Topic: fixes
Reviewers: brian-k, aaron