### PR TITLE
Use --atomic with git push

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -918,6 +918,7 @@ class TopicStack:
                 "push",
                 "--force",
                 "--no-verify",
+                "--atomic",
                 "--quiet" if self.git_ctx.sh.quiet else "--verbose",
                 self.git_ctx.remote_name,
                 *push_targets,


### PR DESCRIPTION
This may or may not help cases where pushing
with rebase ends up triggering server side hooks
for upstream files.

Topic: atomicpush
Reviewers: brian-k