### PR TITLE
Add better error handling for github responses

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -3,7 +3,12 @@ import logging
 import sys
 
 from revup.revup import main
-from revup.types import RevupConflictException, RevupUsageException
+from revup.types import (
+    RevupConflictException,
+    RevupGithubException,
+    RevupShellException,
+    RevupUsageException,
+)
 
 
 def _main() -> None:
@@ -16,6 +21,15 @@ def _main() -> None:
     except RevupConflictException as e:
         logging.error(str(e))
         sys.exit(3)
+    except RevupShellException as e:
+        logging.error(str(e))
+        sys.exit(4)
+    except RevupGithubException as e:
+        for error in e.error_json:
+            logging.error("{}: {}".format(error["type"], error["message"]))
+
+        logging.warning("{} operations failed!".format(len(e.error_json)))
+        sys.exit(5)
 
 
 if __name__ == "__main__":

--- a/revup/github.py
+++ b/revup/github.py
@@ -4,7 +4,7 @@ from typing import Any
 
 class GitHubEndpoint(metaclass=ABCMeta):
     @abstractmethod
-    async def graphql(self, query: str, require_success: bool = True, **kwargs: Any) -> Any:
+    async def graphql(self, query: str, **kwargs: Any) -> Any:
         """
         Args:
             query: string GraphQL query to execute

--- a/revup/types.py
+++ b/revup/types.py
@@ -1,4 +1,4 @@
-from typing import NewType
+from typing import Dict, NewType
 
 # A bunch of commonly used type definitions.
 
@@ -22,3 +22,13 @@ class RevupUsageException(Exception):
 
 class RevupConflictException(Exception):
     pass
+
+
+class RevupShellException(Exception):
+    pass
+
+
+class RevupGithubException(Exception):
+    def __init__(self, error_json: Dict):
+        super().__init__()
+        self.error_json = error_json


### PR DESCRIPTION
If there's a github error, print out the indivudual
messages rather than showing the user the raw json.
Also always print out the topics at the end for updates,
since an error at that stage could still mean that most
operations succeeded.

Topic: errors
Reviewers: brian-k