### PR TITLE
amend --insert inserts after given commit

### DIFF
--- a/docs/amend.md
+++ b/docs/amend.md
@@ -47,7 +47,7 @@ use the old commit message as-is.
 
 **--insert, -i**
 : Instead of amending the given commit, insert the changes in cache
-as a new commit before the given commit. If there are no changes in
+as a new commit after the given commit. If there are no changes in
 cache, this inserts an empty commit. Cannot be used with --no-edit,
 since the new commit requires a commit message.
 

--- a/revup/amend.py
+++ b/revup/amend.py
@@ -1,6 +1,5 @@
 import argparse
 import asyncio
-import copy
 import logging
 import re
 import subprocess
@@ -138,9 +137,8 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
         raise RevupUsageException(f"Couldn't find any commits between HEAD and {commit}~")
 
     if args.insert:
-        # Create a new empty commit with the same tree as its parent
-        stack.insert(0, copy.deepcopy(stack[0]))
-        stack[0].tree = GitTreeHash(f"{stack[0].parents[0]}^{{tree}}")
+        # Create a new empty commit after the given commit
+        stack[0].parents = [stack[0].commit_id]
         # Clear commit specific fields
         stack[0].author_name = ""
         stack[0].author_email = ""


### PR DESCRIPTION
The original ordering was arbitrary, this change
makes it possible to alias "revup commit" as
"revup amend --insert". Previously it would have
been impossible to use --insert to create the top
commit.

Topic: insert
Reviewers: brian-k, malcolm-l