### PR TITLE
upload: Clean up error messages from pre-upload scripts

### DIFF
--- a/revup/upload.py
+++ b/revup/upload.py
@@ -76,12 +76,19 @@ async def main(
             return 1
 
     if args.pre_upload:
-        try:
-            # Wait until we're sure there aren't any conflicts before running pre upload command
-            with get_console().status("Running pre-upload command"):
-                subprocess.check_call(args.pre_upload, shell=True, cwd=git_ctx.sh.cwd)
-        except Exception as e:
-            raise RevupShellException from e
+        # Wait until we're sure there aren't any conflicts before running pre upload command
+        with get_console().status("Running pre-upload command"):
+            result = subprocess.run(
+                args.pre_upload,
+                shell=True,
+                cwd=git_ctx.sh.cwd,
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                encoding="utf-8",
+            )
+            if result.returncode != 0:
+                raise RevupShellException(f"Pre-upload command failed:\n{result.stdout}")
 
     with get_console().status("Pushing remote branches…"):
         if args.patchsets:


### PR DESCRIPTION
When a pre-upload script prints to stdout/stderr, it would print
immediately after the "Running pre-upload command" line (without a
line break or space). If the command failed, the resulting console
error message was empty (resulting in a blank 'E:' line).

Fix both of these by capturing output from the pre-upload script and
stuff it into the exception. When the exception is caught later, the
stdout/stderr will be printed to the console separately with the 'E:'
prefix.

This has the side-effect of suppressing output when the script is
successful.

Signed-off-by: Brian Kubisiak <brian@kubisiak.com>