### PR TITLE
git: Remove --binary from diff args

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -45,7 +45,6 @@ GIT_DIFF_ARGS = [
     "--full-index",
     "--no-color",
     "--no-textconv",
-    "--binary",
     "-U1",
 ]
 


### PR DESCRIPTION
We don't need a binary patch in order to apply
because we just use object ids for 3way.

Git patch-id is broken for all binary diffs, although
its slightly less broken if there is no patch -- it just
produces the same patch-id rather than breaking parsing
for the rest of the commit.

Topic: patchid
Reviewers: brian-k