### PR TITLE
github: Don't query teams yet

### DIFF
--- a/revup/github_utils.py
+++ b/revup/github_utils.py
@@ -236,10 +236,6 @@ async def query_everything(
                                 login
                                 id
                             }}
-                            ... on Team {{
-                                name
-                                id
-                            }}
                         }}
                     }}
                 }}


### PR DESCRIPTION
This requires a new permission for your access token, and
we don't want to make everyone add that.

Topic: teams
Reviewers: brian-k