### PR TITLE
amend: Don't attempt to lookup topics if no github remote

### DIFF
--- a/revup/github_utils.py
+++ b/revup/github_utils.py
@@ -3,43 +3,11 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Set, Tuple
 
-from revup import git, github
+from revup import github
+from revup.git import GitHubRepoInfo
 from revup.types import GitCommitHash
 
-GitHubRepoInfo = NamedTuple(
-    "GitHubRepoInfo",
-    [("name", str), ("owner", str)],
-)
-
 MAX_COMMENTS_TO_QUERY = 3
-
-
-async def get_github_repo_info(
-    *, git_ctx: git.Git, github_url: str, remote_name: str
-) -> GitHubRepoInfo:
-    """
-    Return github repo's name and owner.
-    """
-    remote_url = (await git_ctx.git("remote", "get-url", remote_name))[1]
-    while True:
-        match = rf"^[^@]+@{github_url}:([^/]+)/([^.]+)(?:\.git)?$"
-        m = re.match(match, remote_url)
-        if m:
-            owner = m.group(1)
-            name = m.group(2)
-            break
-        search = rf"{github_url}/([^/]+)/([^.]+)"
-        m = re.search(search, remote_url)
-        if m:
-            owner = m.group(1)
-            name = m.group(2)
-            break
-        owner = ""
-        name = ""
-        break
-
-    info = GitHubRepoInfo(owner=owner, name=name)
-    return info
 
 
 @dataclass

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -160,10 +160,10 @@ def dump_args(args: argparse.Namespace) -> None:
 async def github_connection(
     git_ctx: git.Git, args: argparse.Namespace, conf: config.Config
 ) -> AsyncGenerator[Tuple, None]:
-    from revup import github_real, github_utils
+    from revup import github_real
 
-    repo_info = await github_utils.get_github_repo_info(
-        git_ctx=git_ctx, github_url=args.github_url, remote_name=args.remote_name
+    repo_info = await git_ctx.get_github_repo_info(
+        github_url=args.github_url, remote_name=args.remote_name
     )
 
     if not repo_info.owner or not repo_info.name:
@@ -177,8 +177,8 @@ async def github_connection(
 
     fork_info = repo_info
     if args.fork_name and args.fork_name != args.remote_name:
-        fork_info = await github_utils.get_github_repo_info(
-            git_ctx=git_ctx, github_url=args.github_url, remote_name=args.fork_name
+        fork_info = await git_ctx.get_github_repo_info(
+            github_url=args.github_url, remote_name=args.fork_name
         )
 
     if not fork_info.owner or not fork_info.name:
@@ -338,6 +338,14 @@ async def main() -> int:
 
         # "commit" is an alias of "amend --insert"
         args.insert = args.cmd == "commit" or args.insert
+
+        repo_info = await git_ctx.get_github_repo_info(
+            github_url=args.github_url, remote_name=args.remote_name
+        )
+
+        if not repo_info.owner or not repo_info.name:
+            # Don't try to get topics for repos that are not in use with github
+            args.parse_topics = False
 
         return await amend.main(args=args, git_ctx=git_ctx)
 


### PR DESCRIPTION
If we're in a repo with no remote, or no github remote, don't
attempt the topics lookup at all as we assume the user isn't
using "revup upload" in this repo.

This slightly speeds up and avoids some errors.

Topic: amend_lookup
Reviewers: brian-k