### PR TITLE
patchsets: Make virtual diff target with shared history

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -303,6 +303,8 @@ class TopicStack:
                 diff_base = review.base_ref
             elif review.base_ref != review.pr_info.baseRefOid:
                 # Rebased review, make a virtual diff target
+                if self.last_virtual_diff_target is None:
+                    self.last_virtual_diff_target = GitCommitHash(self.base_branch)
                 self.last_virtual_diff_target = await self.git_ctx.make_virtual_diff_target(
                     review.pr_info.baseRefOid,
                     review.pr_info.headRefOid,


### PR DESCRIPTION
Previously we just made the first virtual diff target with no parent
resulting in a branch with no shared history with any other
branch. Strictly this shouldn't matter as we only use the
branch for diffs, but we've seen a few cases where pushing this
branch is specifically causing git push to take an incredibly
long time. I don't have a great way to explain this as the virtual
diff target should only be pushing the tree itself, all blobs within
it reuse blobs that were already present in the repo.

Try to create the target with a shared history from an
arbitrary commit to see if this resolves the issues we see.

Topic: vritdiff
Reviewers: brian-k