### PR TITLE
Fail on bad response status

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -6,6 +6,7 @@ from revup.revup import main
 from revup.types import (
     RevupConflictException,
     RevupGithubException,
+    RevupRequestException,
     RevupShellException,
     RevupUsageException,
 )
@@ -30,6 +31,10 @@ def _main() -> None:
 
         logging.warning("{} operations failed!".format(len(e.error_json)))
         sys.exit(5)
+    except RevupRequestException as e:
+        logging.error(f"Request failed with response status {e.status}")
+        logging.error(f"Response: {e.response}")
+        sys.exit(6)
 
 
 if __name__ == "__main__":

--- a/revup/github_real.py
+++ b/revup/github_real.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Tuple, Union
 from aiohttp import ClientSession
 
 from revup import github
-from revup.types import RevupGithubException
+from revup.types import RevupGithubException, RevupRequestException
 
 
 class RealGitHubEndpoint(github.GitHubEndpoint):
@@ -85,5 +85,8 @@ class RealGitHubEndpoint(github.GitHubEndpoint):
 
             if "errors" in r:
                 raise RevupGithubException(r["errors"])
+
+            if resp.status != 200:
+                raise RevupRequestException(resp.status, r)
 
         return r

--- a/revup/types.py
+++ b/revup/types.py
@@ -32,3 +32,10 @@ class RevupGithubException(Exception):
     def __init__(self, error_json: Dict):
         super().__init__()
         self.error_json = error_json
+
+
+class RevupRequestException(Exception):
+    def __init__(self, status: int, response: Dict):
+        super().__init__()
+        self.status = status
+        self.response = response


### PR DESCRIPTION
Previously we could get responses from the github api like:

```
Response status: 401 took 0.21685314178466797
Response JSON:
{
 "message": "Bad credentials",
 "documentation_url": "https://docs.github.com/graphql"
}

```

But continue on and fail with something like:
```
Traceback (most recent call last):
  File "/.../lib/python3.8/site-packages/revup/__main__.py", line 17, in _main
    sys.exit(asyncio.run(main()))
  File "/usr/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/.../lib/python3.8/site-packages/revup/revup.py", line 357, in main
    return await upload.main(
  File "/.../lib/python3.8/site-packages/revup/upload.py", line 46, in main
    await topics.query_github()
  File "/.../lib/python3.8/site-packages/revup/topic_stack.py", line 961, in query_github
    ) = await github_utils.query_everything(
  File "/.../lib/python3.8/site-packages/revup/github_utils.py", line 290, in query_everything
    this_node = pr_result["data"]["repository"][prs_out[i]]
KeyError: 'data'
```

Now you get an error like:
```
E: Request failed with response status 401
E: Response: {'message': 'Bad credentials', 'documentation_url': 'https://docs.github.com/graphql'}
```

Not sure if we should treat any 200 status as ok or something, or just
400 statuses as errors, etc.

Reviewers: jerry,brian-k
Topic: status-fail