### PR TITLE
config: Reorganize config code and add config command

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,56 @@
+# NAME
+
+revup config - Edit revup configuration files.
+
+# SYNOPSIS
+
+`revup config [--help] [--repo] <flag> <value>`
+
+# DESCRIPTION
+
+Revup stores some persistent configuration values in a python configparser
+compatible format. A repo specific configuration is read from the root of
+the current git repo in a ".revupconfig" file. A user configuration is read
+from REVUP_CONFIG_PATH if available, otherwise from the default path of
+~/.revupconfig. Any flag or argument to a revup command can
+be configured. Revup loads options in this order:
+
+- The program has built in defaults that are given in the manual.
+- Repo configs take precedence over the above.
+- User configs take precedence over the above.
+- Command line flags specified by the user take highest precedence.
+
+# OPTIONS
+
+**`<flag>`**
+: The name of the flag to be configured. Flags for revup subcommands can be
+specified with "command.flag". Dashes will be replaced with underscores in the
+underlying file.
+
+**`<value>`**
+: The desired value of the flag. Booleans are specified as "true" and "false".
+If no value is specified, the user will be prompted to input the value in a
+secure prompt. This is the preferred way to set certain sensitive fields, and
+revup will warn if attempting to specify them directly.
+
+**--help, -h**
+: Show this help page.
+
+**--repo, -r**
+: If specified, configuration value will be written to the file in the current
+repo. Otherwise, value will apply globally.
+
+# EXAMPLES
+
+The default value for `revup upload --skip-confirm` is `false`. The user
+can override this by running
+
+: $ `revup config upload.skip_confirm true`
+
+which adds this section to .revupconfig.
+```
+[upload]
+skip_confirm = True
+```
+If the user then wants to temporarily override their config, they can
+run `revup upload --no-skip-confirm`.

--- a/docs/revup.md
+++ b/docs/revup.md
@@ -12,6 +12,13 @@ Revup is a python command-line toolkit for speeding up your
 git workflow. It provides commit-based development support and
 full github integration.
 
+All revup options can be given with a shorter unambiguous prefix.
+
+For boolean flags where the default value is "true", the flag can be
+negated by prefixing "--no-" to the long form, or "-n" to the short
+for if it exists. If several forms of a flag are given on the command
+line, the value of the last one will be used.
+
 # OPTIONS
 
 **--verbose, -v**
@@ -109,34 +116,11 @@ given branch relative to its base branch, then cherry-pick it.
 **revup restack**
 : Reorder the current stack so that commits in a topic are consecutive.
 
+**revup config**
+: Edit configuration and set default values for command flags.
+
 **revup toolkit**
 : Various low-level subfunctionalities intended for advanced users or scripts.
-
-# CONFIGURATION
-Revup stores some persistent configuration values in a python configparser
-compatible format. Any flag or argument to a revup command can be configured.
-Revup loads options the following way, in order of lowest to highest precedence:
-
-- The program has built in defaults that are given in the manual.
-- Repo config is loaded from ".revupconfig" in the root of the current repo.
-- User config is loaded from REVUP_CONFIG_PATH if available, otherwise "~/.revupconfig".
-- User's specified command-line flags.
-
-Each command corresponds to a section in the config file, and each flag
-corresponds to a key with "-" replaced with "_".
-Boolean flags can be negated on the command line by prefixing "--no-" to the
-long form, or "-n" to the short for if it exists.
-
-**Example:**
-The default value for `revup upload --skip-confirm` is `false`. The user
-can override this by adding this section to .revupconfig.
-```
-[upload]
-skip_confirm = True
-```
-If the user then wants to temporarily override their config, they can
-run `revup upload --no-skip-confirm`.
-
 
 # ISSUES
 

--- a/revup/config.py
+++ b/revup/config.py
@@ -1,56 +1,102 @@
+import argparse
 import configparser
 import getpass
+import logging
 import os
 import re
 
+from revup.types import RevupUsageException
+
 
 class Config:
+    # Object containing configuration values. Populated by read(), and can then
+    # be modified by set_value()
     config: configparser.ConfigParser
+
+    # Path to user global config file
     config_path: str
 
-    def __init__(self, config_path: str, repo_config_path: str):
+    # Path to config file in current repo
+    repo_config_path: str
+
+    # Whether the config contains values that need to be flushed to the file
+    dirty: bool = False
+
+    def __init__(self, config_path: str, repo_config_path: str = ""):
         self.config = configparser.ConfigParser()
         self.config_path = config_path
         self.repo_config_path = repo_config_path
 
     def read(self) -> None:
-        write_back = False
-        if not os.path.exists(self.config_path):
-            write_back = True
+        if self.repo_config_path:
+            self.config.read(self.repo_config_path)
+        if self.config_path:
+            self.config.read(self.config_path)
 
-        self.config.read(self.config_path)
+    def write(self) -> None:
+        if not self.dirty:
+            return
 
-        if not self.config.has_section("revup"):
-            self.config.add_section("revup")
-            write_back = True
+        # Ensure the file is created with secure permissions, due to containing credentials
+        with os.fdopen(
+            os.open(self.config_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600), "w"
+        ) as f:
+            self.config.write(f)
+        self.dirty = False
 
-        if not self.config.has_option("revup", "github_username"):
-            github_username = input("GitHub username: ")
-            # From https://www.npmjs.com/package/github-username-regex :
-            # Github username may only contain alphanumeric characters or hyphens.
-            # Github username cannot have multiple consecutive hyphens.
-            # Github username cannot begin or end with a hyphen.
-            # Maximum is 39 characters.
-            if not re.match(r"^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$", github_username, re.I):
-                raise ValueError(f"{github_username} is not a valid GitHub username")
-            self.config.set("revup", "github_username", github_username)
-            write_back = True
+    def set_value(self, section: str, key: str, value: str) -> None:
+        if not self.config.has_section(section):
+            self.config.add_section(section)
+            self.dirty = True
 
-        if not self.config.has_option("revup", "github_oauth"):
-            github_oauth = getpass.getpass(
-                "GitHub OAuth token (make one at "
-                "https://github.com/settings/tokens/new -- "
-                'we need full "repo" permissions): '
-            ).strip()
-            self.config.set("revup", "github_oauth", github_oauth)
-            write_back = True
-
-        if write_back:
-            # Ensure the file is created with secure permissions, due to containing credentials
-            with os.fdopen(os.open(self.config_path, os.O_WRONLY | os.O_CREAT, 0o600), "w") as f:
-                self.config.write(f)
-
-        self.config.read(self.repo_config_path)
+        if not self.config.has_option(section, key) or self.config.get(section, key) != value:
+            self.config.set(section, key, value)
+            self.dirty = True
 
     def get_config(self) -> configparser.ConfigParser:
         return self.config
+
+
+def config_main(conf: Config, args: argparse.Namespace) -> int:
+    split_key = args.flag[0].replace("-", "_").split(".")
+    if len(split_key) == 1:
+        command = "revup"
+        key = split_key[0]
+    elif len(split_key) == 2:
+        command = split_key[0]
+        key = split_key[1]
+    else:
+        raise RevupUsageException("Invalid flag argument (must be <key> or <command>.<key>)")
+
+    if not args.value:
+        value = getpass.getpass(f"Input value for {command}.{key}: ").strip()
+    else:
+        value = args.value
+
+        if command == "revup" and key == "github_oauth":
+            logging.warning(
+                "Prefer to omit the value on command line when entering sensitive info. "
+                "You may want to clear your shell history."
+            )
+
+    config_path = conf.repo_config_path if args.repo else conf.config_path
+    this_config = Config(config_path)
+    this_config.read()
+
+    if command == "revup" and key == "github_username":
+        # From https://www.npmjs.com/package/github-username-regex :
+        # Github username may only contain alphanumeric characters or hyphens.
+        # Github username cannot have multiple consecutive hyphens.
+        # Github username cannot begin or end with a hyphen.
+        # Maximum is 39 characters.
+        if not re.match(r"^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$", value, re.I):
+            raise ValueError(f"{args.value} is not a valid GitHub username")
+    elif command == "revup" and key == "github_oauth":
+        if not re.match(r"^[a-z\d_]+$", value, re.I):
+            raise ValueError("Input string is not a valid oauth")
+    elif command == "config":
+        raise RevupUsageException("Can't set defaults for the config command itself")
+
+    this_config.set_value(command, key, value)
+    this_config.write()
+    return 0


### PR DESCRIPTION
In order to simplify the config code and provide people
an easier way to edit their configs, move most of the writing
logic out of the read() fn and into write() and set_value()
functions. Running normal revup commands will no longer write
to the config, instead only "revup config" will be able
to write arbitrary config values. This means that users will
no longer be required to enter an oauth for commands that
don't talk to github, and if a command requires oauth, it
will instead prompt users to run "revup config".

Topic: config