### PR TITLE
Fix error messages for unknown error types

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -26,7 +26,8 @@ def _main() -> None:
         sys.exit(4)
     except RevupGithubException as e:
         for error in e.error_json:
-            logging.error("{}: {}".format(error["type"], error["message"]))
+            error_type = error["type"] if "type" in error else "Unknown Error"
+            logging.error("{}: {}".format(error_type, error["message"]))
 
         logging.warning("{} operations failed!".format(len(e.error_json)))
         sys.exit(5)


### PR DESCRIPTION
At least some of the time, the response can look like:

```
{'errors': [{'message': 'Parse error on "poopy" (IDENTIFIER) at [1, 1]', 'locations': [{'line': 1, 'column': 1}]}]}
```

which means the handler code throws with something like:

```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/.../revup/__main__.py", line 29, in _main
    logging.error("{}: {}".format(error["type"], error["message"]))
KeyError: 'type'
```

Now you'll get something like:
```
E: Unknown Error: Parse error on "poopy" (IDENTIFIER) at [1, 1]
W: 1 operations failed!
```

Not sure if some errors still contain `type`, or if the GitHub GraphQL
API doesn't return that anymore.  Either way, handling both cases.

Reviewers: jerry,brian-k
Topic: unknown-error-types