### PR TITLE
Makefile uses python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BUILD_DIR=build
 
-PYTHON ?= /usr/bin/env python3.8
+PYTHON ?= /usr/bin/env python3
 
 all: deps lint man package install
 


### PR DESCRIPTION
Just a suggestion - this makes the makefile work out-of-the-box in
environments with other python versions besides 3.8

Reviewers: jerry,brian-k
Topic: make-py3