### PR TITLE
[Makefile] Add pandoc and python-venv to apt installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ all: deps lint man package install
 deps:
 	$(PYTHON) -m pip install black isort pylint mypy build twine pytest pytest-mock
 	$(PYTHON) -m pip install .
+	sudo apt install pandoc python3-venv
 
 # Format using black
 BLACK_CMD=$(PYTHON) -m black --line-length 100 -t py38 --preview --exclude "build/.*|\.eggs/.*"


### PR DESCRIPTION
Makefile install was not working on WSL due to pandoc and python-venv not being installed.

This was the fix I hacked to get it to work, but there might be something better rather than doing sudo apt install.

Topic: makefile-fix