### PR TITLE
git: Don't update index if file list is empty

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -735,6 +735,10 @@ class Git:
         ):
             new_index.append(f"{m.group('new_mode')} {m.group('new_hash')} 0\t{m.group('path')}")
 
+        if not new_index:
+            # No files were actually changed, so no diff needs to be applied to new_base
+            return new_base
+
         temp_index_path = self.get_scratch_dir() + "/index.temp"
         git_env = {
             "GIT_INDEX_FILE": temp_index_path,


### PR DESCRIPTION
When making a virtual diff target of an empty old_head,
we would first find the diff of the commit. However if this
diff is empty, we'd pass an empty string to git update-index
which would then hang as it is expecting at least one input.

Solution is to not call update-index at all if there is no diff
as it is not necessary. We can just return new_base.

Topic: fix_hang
Reviewers: brian-k