### PR TITLE
Allow specifying topics to upload

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -9,7 +9,7 @@ revup upload - Modify or create code reviews.
 `[--rebase] [--relative-chain] [--skip-confirm] [--dry-run]`
 `[--status] [--no-cherry-pick] [--no-update-pr-body] [--review-graph]`
 `[--trim-tags] [--create-local-branches] [--patchsets] [--auto-add-users=<o>]`
-`[--labels=<labels>]`
+`[--labels=<labels>] [<topics>]`
 
 # DESCRIPTION
 
@@ -95,6 +95,11 @@ any changes. In this case a user should specify relative topics such
 that conflicts will not happen.
 
 # OPTIONS
+
+**`<topics>`**
+: Optionally specify any number of topic names to upload. If none are
+specified, all topics are uploaded. If topics are specified they will
+be uploaded regardless of author.
 
 **--help, -h**
 : Show this help page.

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -228,6 +228,7 @@ async def main() -> int:
         p.add_argument("--base-branch", "-b")
         p.add_argument("--relative-branch", "-e")
 
+    upload_parser.add_argument("topics", nargs="*")
     upload_parser.add_argument("--rebase", "-r", action="store_true")
     upload_parser.add_argument("--skip-confirm", "-s", action="store_true")
     upload_parser.add_argument("--dry-run", "-d", action="store_true")

--- a/revup/upload.py
+++ b/revup/upload.py
@@ -39,6 +39,7 @@ async def main(
             user_aliases=args.user_aliases,
             auto_add_users=args.auto_add_users,
             self_authored_only=args.self_authored_only,
+            limit_topics=args.topics,
         )
 
     if not args.dry_run:


### PR DESCRIPTION
As a list of multiple arguments to upload.

If topics are specified, only those topics will be uploaded.
Those topics will also ignore no-self-authored-only.
Any topics that aren't found will warn.

Topic: onlytopics
Reviewers: brian-k