### PR TITLE
Bump required git version to 2.39

### DIFF
--- a/revup/revup.py
+++ b/revup/revup.py
@@ -104,7 +104,7 @@ def make_toplevel_parser() -> RevupArgParser:
     revup_parser.add_argument("--git-path", default="")
     revup_parser.add_argument("--main-branch", default="main")
     revup_parser.add_argument("--base-branch-globs", default="")
-    revup_parser.add_argument("--git-version", default="2.36.0")
+    revup_parser.add_argument("--git-version", default="2.39.0")
     return revup_parser
 
 


### PR DESCRIPTION
This is one older than the latest release, and is required
for new flags as well as the merge-tree command.

Topic: bump
Reviewers: brian-k