### PR TITLE
Pass --verbatim to git patch-id

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -590,7 +590,7 @@ class Git:
         ret = (
             await self.sh.piped_sh(
                 patch_source,
-                [self.git_path, "patch-id", "--stable"],
+                [self.git_path, "patch-id", "--verbatim"],
             )
         )[1].split()
         # If the diff is empty, patch id will return nothing. We just use that as the patch-id since


### PR DESCRIPTION
The patches to fix the whitespace issues with revup upload
have made it into mainstream git. We just need to enable the
new whitespace included patch id with the new flag.

This should fix issues where revup upload thinks no changes have
been made even though some have, but only to whitespace.

Topic: ws
Reviewers: brian-k