### PR TITLE
upload: Allow any head to be specified

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -192,3 +192,6 @@ mappings are used to transform usernames specified in Reviewers/Assignees.
 **--auto-add-users**
 : If "no", do nothing extra. If "r2a", add users from the Reviewers tag as assignees.
 If "a2r", add users from the Assignees tag as reviewers. If "both", do both of the previous.
+
+**--head**
+: The name or commit of the branch to be uploaded. If not specified, defaults to HEAD.

--- a/revup/git.py
+++ b/revup/git.py
@@ -484,8 +484,8 @@ class Git:
         self, commit: str, limit_to_base_branches: bool = True, allow_self: bool = True
     ) -> List[str]:
         """
-        Find the best base branch for the current HEAD by listing candidate remote branches
-        Return the branch(es) with the shortest distance from HEAD to fork-point
+        Find the best base branch for the given commit by listing candidate remote branches
+        Return the branch(es) with the shortest distance from the commit to fork-point
         """
         branches = await self.find_remote_branches(commit, limit_to_base_branches, True)
         candidates: List[Tuple[int, str]] = []

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -249,6 +249,7 @@ async def main() -> int:
     upload_parser.add_argument("--pre-upload", "-p")
     upload_parser.add_argument("--relative-chain", "-c", action="store_true")
     upload_parser.add_argument("--auto-topic", "-a", action="store_true")
+    upload_parser.add_argument("--head", default="HEAD")
 
     restack_parser.add_argument("--topicless-last", "-t", action="store_true")
 

--- a/revup/upload.py
+++ b/revup/upload.py
@@ -26,6 +26,7 @@ async def main(
         github_ep,
         repo_info,
         fork_info,
+        args.head,
     )
     with get_console().status("Finding topics…"):
         await topics.populate_topics(


### PR DESCRIPTION
Sometimes a user may want to upload a full stack that is
different than their current HEAD (perhaps something just
fetched from remote, but they can save effort by not needing
to check out). This adds a flag so that any ref can be used
as HEAD instead.

Topic: head
Reviewers: brian-k