### PR TITLE
Avoid main branch not found error.

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -181,7 +181,7 @@ async def make_git(
         git_ctx.git_stdout("--version"),
         get_email(),
         get_editor(),
-        git_ctx.commit_exists(main_branch),
+        git_ctx.commit_exists(f"{remote_name}/{main_branch}"),
     )
 
     if git_version:


### PR DESCRIPTION
The intent of this was to check whether an origin branch
by this name exists, but it was checking local branches.

This fixes some errors for repos that don't have a local
branch called "main" or "master".

Topic: erbr
Reviewers: brian-k