### PR TITLE
Use asyncio.gather to run patch-ids in parallel

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import subprocess
@@ -666,10 +667,9 @@ class TopicStack:
             else:
                 if not topic.patch_ids:
                     # Lazily load patch ids for the topic.
-                    # TODO async gather to generate patch ids in parallel
-                    topic.patch_ids = [
-                        await self.git_ctx.get_patch_id(c.commit_id) for c in topic.original_commits
-                    ]
+                    topic.patch_ids = await asyncio.gather(
+                        *(self.git_ctx.get_patch_id(c.commit_id) for c in topic.original_commits)
+                    )
 
                 review.remote_commits = git.parse_rev_list(
                     await self.git_ctx.rev_list(
@@ -680,10 +680,9 @@ class TopicStack:
                     )
                 )
 
-                # TODO async gather to generate patch ids in parallel
-                review.remote_patch_ids = [
-                    await self.git_ctx.get_patch_id(c.commit_id) for c in review.remote_commits
-                ]
+                review.remote_patch_ids = await asyncio.gather(
+                    *(self.git_ctx.get_patch_id(c.commit_id) for c in review.remote_commits)
+                )
 
                 # This review is a rebase iff all commit diffs match
                 is_rebase = len(review.remote_commits) == len(topic.original_commits) and all(


### PR DESCRIPTION
This makes the patch id process slightly faster for topics
with multiple commits.

Topic: async
Reviewers: brian-k