### PR TITLE
upload: Improve is_on_correct_base logic

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -413,6 +413,8 @@ class Git:
         This is different from merge-base --is-ancestor since that checks all
         parents, not just the first.
         """
+        if ref == ancestor:
+            return True
         return await self.distance_to_fork_point(ref, ancestor, 1) == 0
 
     async def have_identical_trees(self, ref1: GitCommitHash, ref2: GitCommitHash) -> bool:


### PR DESCRIPTION
Previously this logic checked only if topic was on top
of its relative branch. If it had no relative branch, it
always assumed the base is correct, which may not be true.

Update the logic for non-relative reviews to check if the remote
parent commit is an ancestor of the local base ref. If it is,
this indicates that the review should be a rebase. If it is not,
the base must have moved and the review needs to be pushed.

This will take a tiny bit more time to run for cases where the
ancestor check triggers (patch ids match but parent doesn't match
exactly).

Topic: uploadbase
Reviewers: brian-k