### PR TITLE
Only raise in parse_topics when uploading

### DIFF
--- a/revup/upload.py
+++ b/revup/upload.py
@@ -32,6 +32,7 @@ async def main(
         await topics.populate_topics(
             auto_topic=args.auto_topic,
             trim_tags=args.trim_tags,
+            raise_on_invalid=True,
         )
         await topics.populate_reviews(
             args.uploader if args.uploader else git_ctx.author,


### PR DESCRIPTION
amend will populate topics so that it can use topic names
to locate commits. However in the case that there is format
or usage error in the commit text, we don't want to raise
at this point since it prevents amend from being used to fix
it in the first place.

Topic: raise
Reviewers: brian-k