### PR TITLE
Add a simple LRU cache to common git cmds

### DIFF
--- a/revup/amend.py
+++ b/revup/amend.py
@@ -237,5 +237,5 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
     git_env = {
         "GIT_REFLOG_ACTION": "reset --soft (revup amend)",
     }
-    await git_ctx.git("reset", "--soft", new_commit, env=git_env)
+    await git_ctx.soft_reset(new_commit, git_env)
     return 0

--- a/revup/cherry_pick.py
+++ b/revup/cherry_pick.py
@@ -14,7 +14,8 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
     branch_to_pick = args.branch[0]
     remote_branch_to_pick = git_ctx.ensure_branch_prefix(branch_to_pick)
     branch_exists, remote_branch_exists = await asyncio.gather(
-        git_ctx.commit_exists(branch_to_pick), git_ctx.commit_exists(remote_branch_to_pick)
+        git_ctx.is_branch_or_commit(branch_to_pick),
+        git_ctx.is_branch_or_commit(remote_branch_to_pick),
     )
     if remote_branch_exists and not branch_exists:
         logging.warning(

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -915,7 +915,7 @@ class TopicStack:
 
         to_fetch = set()
         for _, _, _, review in self.all_reviews_iter():
-            if review.pr_info is not None and not await self.git_ctx.commit_exists(
+            if review.pr_info is not None and not await self.git_ctx.is_branch_or_commit(
                 review.pr_info.headRefOid
             ):
                 to_fetch.add(review.pr_info.headRefOid)
@@ -1289,7 +1289,7 @@ class TopicStack:
         git_env = {
             "GIT_REFLOG_ACTION": "reset --soft (revup restack)",
         }
-        await self.git_ctx.git("reset", "--soft", new_parent, env=git_env)
+        await self.git_ctx.soft_reset(new_parent, git_env)
         return new_parent
 
     def num_reviews_changed(self) -> int:


### PR DESCRIPTION
Simple commands such as ref existence, id lookup,
and distance lookup are pretty common and could be
called with the same args at a higher level such that
its difficult to dedupe between calls. To speed things
up, add a lru_cache decorator so that later calls are
looked up. We don't add this to everything since
more complex functions are unlikely to be called with
the same args multiple times.

These calls are mostly pure functions since revup
generally doesn't change the git database. There are
a few exceptions to that, when it runs "reset" for certain
commands. In these cases, we empty all caches just to be safe.

Topic: cache
Reviewers: brian-k