### PR TITLE
git: Switch cherry-pick backend to git merge-tree

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -20,7 +20,7 @@ def _main() -> None:
         logging.error(str(e))
         sys.exit(2)
     except RevupConflictException as e:
-        logging.error(str(e))
+        logging.error(e.message)
         sys.exit(3)
     except RevupShellException as e:
         logging.error(str(e))

--- a/revup/logs.py
+++ b/revup/logs.py
@@ -57,7 +57,7 @@ def configure_logger(debug: bool, redactions: Dict[str, str]) -> None:
     log_filter = RedactingFilter()
     for k, v in redactions.items():
         log_filter.redact(k, v)
-    handler = RevupRichHandler()
+    handler = RevupRichHandler(keywords=[])
     handler.addFilter(log_filter)
     handler.set_render(
         LogRender(
@@ -67,6 +67,7 @@ def configure_logger(debug: bool, redactions: Dict[str, str]) -> None:
             level_width=1,
         )
     )
+    handler.highlighter = None  # type: ignore
 
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)

--- a/revup/restack.py
+++ b/revup/restack.py
@@ -1,8 +1,6 @@
 import argparse
-import logging
 
 from revup import git, topic_stack
-from revup.types import GitConflictException
 
 
 async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
@@ -19,9 +17,5 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
 
     await topics.populate_topics()
 
-    try:
-        await topics.restack(args.topicless_last)
-        return 0
-    except GitConflictException as e:
-        logging.error(str(e))
-        return 1
+    await topics.restack(args.topicless_last)
+    return 0

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -881,11 +881,13 @@ class TopicStack:
                                 else f'base branch "{base_branch}"'
                             )
                         )
+                        await self.git_ctx.dump_conflict(exc)
                         raise RevupConflictException(
-                            "Failed to cherry-pick commit:\n"
-                            f'"{commit.title}" ({commit.commit_id[:8]}) in topic "{name}"\n'
-                            f"to new parent ({next_parent[:8]}) in {parent_info}\n\n"
-                            "You must specify relative branches to prevent this conflict!"
+                            commit,
+                            next_parent,
+                            "You must specify relative branches to prevent this conflict!",
+                            f' in topic "{name}"',
+                            f" in {parent_info}",
                         ) from exc
                     review.new_commits.append(next_parent)
 
@@ -1284,11 +1286,11 @@ class TopicStack:
                     commit, new_parent
                 )
             except GitConflictException as exc:
+                await self.git_ctx.dump_conflict(exc)
                 raise RevupConflictException(
-                    "Failed to cherry-pick commit:\n"
-                    f'"{commit.title}" ({commit.commit_id[:8]})\n'
-                    f"to new parent ({new_parent[:8]})\n\n"
-                    f"You may need to `git rebase -i {new_parent[:8]}` to resolve these conflicts!"
+                    commit,
+                    new_parent,
+                    "You may need to `git rebase -i` to resolve these conflicts!",
                 ) from exc
         git_env = {
             "GIT_REFLOG_ACTION": "reset --soft (revup restack)",

--- a/revup/upload.py
+++ b/revup/upload.py
@@ -1,12 +1,11 @@
 import argparse
-import logging
 import subprocess
 from typing import Optional
 
 from rich import get_console
 
 from revup import git, github, github_utils, topic_stack
-from revup.types import GitConflictException, RevupShellException
+from revup.types import RevupShellException
 
 
 async def main(
@@ -59,14 +58,9 @@ async def main(
     if args.status:
         return 0
 
-    try:
-        with get_console().status("Creating commits…"):
-            # Need to know rebase information before creating commits
-            await topics.create_commits(args.trim_tags)
-    except GitConflictException as e:
-        logging.error(str(e))
-        logging.error("You need to specify relative topics to prevent this conflict.")
-        return 1
+    with get_console().status("Creating commits…"):
+        # Need to know rebase information before creating commits
+        await topics.create_commits(args.trim_tags)
 
     if args.dry_run:
         topics.print(not args.verbose)


### PR DESCRIPTION
Previously we used a git apply backend that did the job,
but doesn't allow for in depth conflict info. git 2.39
introduces a new git merge-tree command that is simpler,
faster, and provides in depth output about various conflict
types, including conflict types that can't be represented
by conflict markers.

Switch to using merge-tree for usages of synthetic cherry-pick
and amend. Virtual diff sets still use the temp index mechanism
for now since merge-tree does not handle that case.

Dump file conflict markers as well as conflict info whenever
possible.

Topic: merge_tree
Relative: cache
Reviewers: brian-k