### PR TITLE
Remove remote prefix from upload printout

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -1348,8 +1348,9 @@ class TopicStack:
                 maybe_draft = " (draft)" if review.is_draft else ""
 
                 get_console().print(
-                    f"[green]Topic:[/] [bold cyan]{name}[/]{maybe_draft} → "
-                    f"{maybe_relative_topic}{maybe_relative_branch}[bold red]{base}[/]"
+                    f"[green]Topic:[/] [bold cyan]{name}[/]{maybe_draft} →"
+                    f" {maybe_relative_topic}{maybe_relative_branch}[bold"
+                    f" red]{self.git_ctx.remove_branch_prefix(base)}[/]"
                 )
                 logging.debug(f"Base rev: {review.base_ref}")
                 if review.new_commits:


### PR DESCRIPTION
When using a fork this prefix is confusing since the
PR is pushed to origin but the github repo used is "fork".
When not using a fork there is only one remote so it isn't
useful. To simplify both cases, don't print the prefix.

Topic: nopre
Reviewers: brian-k, aaron-m