### PR TITLE
Switch to async_lru for lru_cache()

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -5,8 +5,9 @@ import os
 import re
 import shutil
 import tempfile
-from functools import lru_cache
 from typing import Any, Dict, List, NamedTuple, Optional, Pattern, Tuple
+
+from async_lru import alru_cache as lru_cache
 
 from revup import shell
 from revup.types import (

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ packages =
 python_requires = >=3.8
 install_requires =
     aiohttp
+    async_lru
     rich
 setup_requires = 
     setuptools


### PR DESCRIPTION
Turns out functools.lru_cache doesn't actually work for
coroutines, it ends up caching the coroutine itself which
is useless and crashes if called again.

Switch to async_lru, which provides a dropin replacement.

Topic: async_lru
Reviewers: brian-k