### PR TITLE
Catch and warn on github timeouts

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -26,11 +26,7 @@ def _main() -> None:
         logging.error(str(e))
         sys.exit(4)
     except RevupGithubException as e:
-        for error in e.error_json:
-            error_type = error["type"] if "type" in error else "Unknown Error"
-            logging.error("{}: {}".format(error_type, error["message"]))
-
-        logging.warning("{} operations failed!".format(len(e.error_json)))
+        logging.error(f"Github Exception: {e.type}: {e.message}")
         sys.exit(5)
     except RevupRequestException as e:
         logging.error(f"Request failed with response status {e.status}")

--- a/revup/types.py
+++ b/revup/types.py
@@ -73,6 +73,14 @@ class RevupGithubException(Exception):
     def __init__(self, error_json: Dict):
         super().__init__()
         self.error_json = error_json
+        messages = []
+        self.types = []
+        for error in self.error_json:
+            self.types.append(error["type"] if "type" in error else "Unknown")
+            messages.append(error["message"])
+
+        self.type = " ".join(self.types) if self.types else "None"
+        self.message = "\n".join(messages)
 
 
 class RevupRequestException(Exception):


### PR DESCRIPTION
Its pretty common for us to hit the 10s github
timeout for very large graphql mutations. In pretty
much all of these cases though, the actual changes
in the request did go through, and a subsequent
revup upload will show everything up to date.

To reflect this and make it nicer for users, catch any
github exception that contains 'timeout' and turn it
into a warning instead. This ensures that we show the topic
list. If the user wishes, they can rerun the command to
verify the changes were actually successful.

Topic: githubtimeout
Reviewers: aaron, brian-k