### PR TITLE
amend: Fix double negative in no-edit

### DIFF
--- a/revup/amend.py
+++ b/revup/amend.py
@@ -111,9 +111,9 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
     )
 
     has_diff = has_staged or has_unstaged or args.drop
-    if not has_diff and args.no_edit:
+    if not has_diff and not args.edit:
         return 0
-    if args.insert and args.no_edit:
+    if args.insert and not args.edit:
         raise RevupUsageException("Can't skip wording an inserted commit!")
 
     if args.drop and args.insert:
@@ -164,7 +164,7 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
         stack[0].committer_date = ""
         stack[0].commit_msg = ""
 
-    if not args.no_edit and not args.drop:
+    if args.edit and not args.drop:
         new_msg = invoke_editor_for_commit_msg(
             git_ctx,
             git_ctx.editor,

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -270,7 +270,7 @@ async def main() -> int:
     restack_parser.add_argument("--topicless-last", "-t", action="store_true")
 
     amend_parser.add_argument("ref_or_topic", nargs="?")
-    amend_parser.add_argument("--no-edit", "--skip-reword", "-s", action="store_true")
+    amend_parser.add_argument("--edit", "-s", default=True, action="store_true")
     amend_parser.add_argument("--insert", "-i", action="store_true")
     amend_parser.add_argument("--drop", "-d", action="store_true")
     amend_parser.add_argument("--all", "-a", action="store_true")


### PR DESCRIPTION
Otherwise in order to run with edit false by
default and manually setting it to true, you'd be
passing in --no-no-edit which is silly.