### PR TITLE
git: Add ^commit to rev parse --verify

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -344,7 +344,9 @@ class Git:
 
     @lru_cache(maxsize=None)
     async def is_branch_or_commit(self, obj: str) -> bool:
-        return await self.git_return_code("rev-parse", "--verify", "--quiet", obj) == 0
+        return (
+            await self.git_return_code("rev-parse", "--verify", "--quiet", obj + "^{commit}") == 0
+        )
 
     async def verify_branch_or_commit(self, obj: str) -> None:
         if not await self.is_branch_or_commit(obj):


### PR DESCRIPTION
It seems like rev-parse --verify if given a valid full length
sha hash doesn't look it up in the database by default, it just
returns success. In order to force it to verify that it is a commit,
we need to add an addl string to the command.