### PR TITLE
amend: Force editing if inserting instead of throwing error

### DIFF
--- a/docs/amend.md
+++ b/docs/amend.md
@@ -48,8 +48,8 @@ use the old commit message as-is.
 **--insert, -i**
 : Instead of amending the given commit, insert the changes in cache
 as a new commit after the given commit. If there are no changes in
-cache, this inserts an empty commit. Cannot be used with --no-edit,
-since the new commit requires a commit message.
+cache, this inserts an empty commit. Implies --edit, since the new commit
+requires a commit message.
 
 **--drop, -d**
 : Instead of amending the given commit, drop it and leave any changes

--- a/revup/amend.py
+++ b/revup/amend.py
@@ -110,11 +110,10 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
         get_has_unstaged(),
     )
 
+    args.edit = args.edit or args.insert
     has_diff = has_staged or has_unstaged or args.drop
     if not has_diff and not args.edit:
         return 0
-    if args.insert and not args.edit:
-        raise RevupUsageException("Can't skip wording an inserted commit!")
 
     if args.drop and args.insert:
         raise RevupUsageException("Doesn't make sense to drop and insert")


### PR DESCRIPTION
If a user has configured edit=False but specifies --insert,
the intention is clear enough that they do in fact want to edit.
We can automatically assume this without throwing an error and
forcing them to type out --edit