### PR TITLE
setup: Add missing transitive dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,13 @@ python_requires = >=3.8
 install_requires =
     aiohttp
     async_lru
+    requests
     rich
+    multidict
+    yarl
+    async_timeout
+    charset_normalizer
+    aiosignal
 setup_requires = 
     setuptools
     wheel


### PR DESCRIPTION
Most of these are actually dependencies of aiohttp
but it seem like they're not declared there, causing some
missing package errors for users.

I think if we declare them here it will fix this
issue.