### PR TITLE
Add support for git editor paths containing spaces

### DIFF
--- a/revup/amend.py
+++ b/revup/amend.py
@@ -2,6 +2,7 @@ import argparse
 import asyncio
 import logging
 import re
+import shlex
 import subprocess
 
 from revup import git, topic_stack
@@ -38,7 +39,7 @@ with '#' will be ignored, and an empty message aborts the commit.\n{topic_summar
     with open(git_ctx.get_scratch_dir() + "/COMMIT_EDITMSG", mode="w") as temp_file:
         temp_file.write(f"{commit_msg}\n{comment_text}")
 
-    subprocess.check_call((*(editor.split()), temp_file.name))
+    subprocess.check_call((*shlex.split(editor), temp_file.name))
     with open(temp_file.name, "r") as editor_file:
         msg = editor_file.read()
 


### PR DESCRIPTION
The `amend` command breaks when your git editor path (`git editor core.config`) contains spaces. For example, on my windows machine this option is configured to
```
"C:\\Program Files\\Sublime Text 3\\subl.exe" -w
```
Calling `split()` on this string obviously won't end well. This PR uses `shlex.split()` (thanks ChatGPT!) which returns the array 
```
['"C:\\Program Files\\Sublime Text 3\\subl.exe"', '-w']
```
as expected.