### PR TITLE
Fix "Event loop is closed" error on windows

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -14,8 +14,12 @@ from revup.types import (
 
 def _main() -> None:
     try:
-        # Exit code of 1 is reserved for exception-based exits
-        sys.exit(asyncio.run(main()))
+        # Exit code of 1 is reserved for exception-based exits.
+        # Note: on Windows, asyncio.run() doesn't work properly due to this issue:
+        # https://stackoverflow.com/questions/63860576/asyncio-event-loop-is-closed-when-using-asyncio-run
+        # Since revup makes use of subprocess, we can't use WindowsSelectorEventLoopPolicy.
+        # Instead, we can manually create the event loop and prevent the RuntimeError on shutdown.
+        sys.exit(asyncio.get_event_loop().run_until_complete(main()))
     except RevupUsageException as e:
         logging.error(str(e))
         sys.exit(2)


### PR DESCRIPTION
Switched from `asyncio.run()` to the older style `asyncio.get_event_loop.run_until_complete()`.
Tested on Ubuntu 22.04 and Windows 10. I also tried raising an exception inside `main()` in revup.py to ensure that errors aren't hidden. The only difference seems to be to avoid the premature closing of the event loop in the ProactorEventLoop (which is the only event loop that works with subprocess on Windows).
See [Asyncio event loop is closed when using asyncio.run()](https://stackoverflow.com/questions/63860576/asyncio-event-loop-is-closed-when-using-asyncio-run) for some discussion.