### PR TITLE
Read github credentials from git credential helper

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -808,3 +808,38 @@ class Git:
 
         # TODO: only strictly needs to drop entries for HEAD
         self.clear_cache()
+
+    async def credential(self, **kwargs: Dict[str, str]) -> str:
+        cred = Credential(self, description=kwargs)
+        await cred.fill()
+        return cred.password
+
+
+class Credential():
+    git_ctx: Git
+    description: Dict[str, str]
+
+    def __init__(self, git: Git, description: Dict[str, str]):
+        self.git_ctx = git
+        self.description = description
+
+    def __getattr__(self, attr):
+        return self.description[attr]
+
+    async def _run(self, subcommand, input: Dict[str, str]) -> Dict[str, str]:
+        input_str = "\n".join(f"{k}={v}" for k, v in input.items())
+        stdout_str = await self.git_ctx.git_stdout("credential", subcommand, input_str=input_str)
+        stdout = {}
+        for line in stdout_str.splitlines():
+            if line == "":
+                break
+            k, v = line.split("=", 1)
+            stdout[k] = v
+        return stdout
+
+    async def fill(self):
+        self.description = await self._run("fill", self.description)
+
+    async def report(self, success: bool):
+        cmd = "approve" if success else "reject"
+        await self._run(cmd, self.description)

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -200,6 +200,13 @@ async def github_connection(
         )
 
     if not args.github_oauth:
+        args.github_oauth = await git_ctx.credential(
+            protocol="https",
+            host=args.github_url,
+            path=f"/{fork_info.owner}/{fork_info.name}.git",
+        )
+
+    if not args.github_oauth:
         raise RevupUsageException(
             "No Github OAuth token configured! "
             "Make one at https://github.com/settings/tokens/new "


### PR DESCRIPTION
If no `github_oauth` is defined, try to read it from `git credential fill`.

Tested with git-credential-manager.

Note: we don't provide success/fail feedback currently, so expired tokens won't
be invalidated by us.

Fixes: #129