### PR TITLE
makefile: Fix mypy invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ check_format:
 	$(BLACK_CMD) --check --diff .
 	$(ISORT_CMD) --check --diff .
 
-MYPY_COMMAND=$(PYTHON) -m mypy --show-error-code
+MYPY_COMMAND=$(PYTHON) -m mypy --show-error-codes
 check_types:
 	$(MYPY_COMMAND) revup
 


### PR DESCRIPTION
Fixes this error with py 3.10 on test:

mypy: error: ambiguous option: --show-error-code could match --show-error-codes, --show-error-code-links