### PR TITLE
github: Update python minor versions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8.14, 3.9.14, 3.10.7]
+        python-version: [3.8.18, 3.10.10, 3.12.1]
     name: Run lint and install checks
     steps:
       - name: Install pandoc


### PR DESCRIPTION
Update minor versions to the latest releases and
test on 3.12 rather than 3.9.