### PR TITLE
makefile: Fix newlines in revup man headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,17 @@ clean:
 
 REVUP_VERSION:=$(shell $(PYTHON) revup/__init__.py)
 REVUP_DATE ?= Apr 21, 2021
-REVUP_HEADER=---\ntitle: TITLE\nsection: 1\nheader: Revup Manual\nfooter: revup VERSION\ndate: DATE\n---\n
+define REVUP_HEADER
+---
+title: TITLE
+section: 1
+header: Revup Manual
+footer: revup VERSION
+date: DATE
+---
+endef
+export REVUP_HEADER
+
 REVUP_VERSION_HASH?=${shell git rev-parse --short v$(REVUP_VERSION) || echo main}
 
 package: man
@@ -62,7 +72,7 @@ man:
 	cd docs ; \
 	for file in *.md ; do \
 		CMD_NAME=`echo $${file} | awk -F'[.]' '{print $$1}'` ; \
-		echo "$(REVUP_HEADER)" | m4 -DTITLE=$${CMD_NAME} -DVERSION=$(REVUP_VERSION) -DDATE="$(REVUP_DATE)" - | \
+		echo "$${REVUP_HEADER}" | m4 -DTITLE=$${CMD_NAME} -DVERSION=$(REVUP_VERSION) -DDATE="$(REVUP_DATE)" - | \
 		cat - $${file} | pandoc -s -t man > ../revup/man1/$${CMD_NAME}.1 || exit 1 ; \
 		gzip -n -f -k ../revup/man1/$${CMD_NAME}.1 || exit 1 ; \
 	done


### PR DESCRIPTION
Not sure how this broke but I was seeing literal
\n instead of newlines in the generated header +
markdown, which then confuses pandoc and causes man
pages to be formatted wrong.

Switch to using a multiline make variable that is
then exported as a shell variable so newlines are
retained. This also makes it cleaner anyways.