### PR TITLE
toolkit: Add list-topics command

### DIFF
--- a/revup/revup.py
+++ b/revup/revup.py
@@ -338,6 +338,28 @@ async def main() -> int:
     toolkit_closest_branch.add_argument(
         "--allow-self", action="store_true", help='Allow the branch itself to be a valid "closest"'
     )
+    toolkit_list_topics = toolkit_subparsers.add_parser(
+        "list-topics", description="List all topics and their commits"
+    )
+    toolkit_list_topics.add_argument(
+        "--base-branch", "-b", help="Use the given branch as the base instead of autodetecting."
+    )
+    toolkit_list_topics.add_argument(
+        "--relative-branch", "-e", help="Use the given relative branch."
+    )
+    list_topics_commit_options = toolkit_list_topics.add_mutually_exclusive_group()
+    list_topics_commit_options.add_argument(
+        "--commit-ids",
+        "-c",
+        action="store_true",
+        help="Print the IDs for all commits within a topic",
+    )
+    list_topics_commit_options.add_argument(
+        "--titles",
+        "-t",
+        action="store_true",
+        help="Print the titles for all commits within a topic",
+    )
 
     # Do an initial parsing pass, which handles HelpAction
     args = revup_parser.parse_args()

--- a/revup/toolkit.py
+++ b/revup/toolkit.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 
 from revup import git
+from revup.topic_stack import TopicStack
 from revup.types import RevupUsageException
 
 
@@ -56,5 +57,14 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
     elif args.toolkit_cmd == "closest-branch":
         await git_ctx.verify_branch_or_commit(args.branch[0])
         logging.info(await git_ctx.get_best_base_branch(args.branch[0], allow_self=args.allow_self))
+    elif args.toolkit_cmd == "list-topics":
+        topics = TopicStack(git_ctx, args.base_branch, args.relative_branch)
+        await topics.populate_topics()
+        for topic in topics.topics.values():
+            logging.info(topic.name)
+            if args.commit_ids or args.titles:
+                for commit in topic.original_commits:
+                    logging.info(commit.commit_id if args.commit_ids else commit.title)
+                logging.info("")
 
     return 0


### PR DESCRIPTION
The list-topics command lists the topics for the current branch along
with (optionally) the commit ID or commit title of all commits that
are part of the topic. This is useful for scripts that needs a list of
the available topics (e.g. in a prepare-commit-msg git hook).

Signed-off-by: Brian Kubisiak <brian@kubisiak.com>