### PR TITLE
git: Run diff with --no-ext-diff

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -51,6 +51,7 @@ GIT_DIFF_ARGS = [
     "--full-index",
     "--no-color",
     "--no-textconv",
+    "--no-ext-diff",
     "-U1",
 ]
 


### PR DESCRIPTION
Users can install a custom diff frontend for
"git diff" that displays diffs in a different
format, but is not compatible with patch-id. To
make sure this doesn't break revup, run diffs with
--no-ext-diff to ensure that only core diff is used.