### PR TITLE
makefile: Pin black version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ all: deps lint man package install
 
 # Install dependent pip packages, needed to lint or build
 deps:
-	$(PYTHON) -m pip install black isort pylint mypy build twine pytest pytest-mock
-	$(PYTHON) -m pip install .
+	$(PYTHON) -m pip install .[dev]
 
 # Format using black
 BLACK_CMD=$(PYTHON) -m black --line-length 100 -t py38 --preview --exclude "build/.*|\.eggs/.*"

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ include_package_data=True
 
 [options.extras_require]
 dev =
-    black
+    black==24.1.1
     isort
     pylint
     mypy


### PR DESCRIPTION
Black keeps updating in the background and breaking our
CI due to slightly different formatting between versions.
Fix this by pinning the version.