### PR TITLE
github: Also catch ContentTypeError

### DIFF
--- a/revup/github_real.py
+++ b/revup/github_real.py
@@ -3,7 +3,7 @@ import logging
 import time
 from typing import Any, Optional, Tuple, Union
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ContentTypeError
 
 from revup import github
 from revup.types import RevupGithubException, RevupRequestException
@@ -76,8 +76,8 @@ class RealGitHubEndpoint(github.GitHubEndpoint):
             )
             try:
                 r = await resp.json()
-            except ValueError:
-                logging.debug("Response body:\n{}".format(await resp.text()))
+            except (ValueError, ContentTypeError):
+                logging.warning("Response body:\n{}".format(await resp.text()))
                 raise
             else:
                 pretty_json = json.dumps(r, indent=1)


### PR DESCRIPTION
Try to get some more info from this trace

  File "/home/jerry/revup/revup/github_real.py", line 78, in graphql
    r = await resp.json()
  File "/home/jerry/.local/lib/python3.8/site-packages/aiohttp/client_reqrep.py", line 1165, in json
    raise ContentTypeError(
aiohttp.client_exceptions.ContentTypeError: 0, message='Attempt to decode JSON with unexpected mimetype: text/html; charset=utf-8', url=URL('https://api.github.com/graphql')