### PR TITLE
upload: Allow arbitrary topic order

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -40,9 +40,7 @@ consecutive locally.
 : Optionally specifies a relative topic for this topic. Each topic can
 have at most one relative topic. Commits in this topic will be cherry-picked
 on top of the branch for the relative topic, and the pull request will
-be created targeted to the relative topic's branch. The first commit
-of a relative topic must appear before the first commit of specifying
-topic.
+be created targeted to the relative topic's branch.
 
 **Branches:**
 : Optionally specifies base branches for this topic. Base branches are long


### PR DESCRIPTION
Now that we're iterating over topics topologically
in the important places, we can remove the check
that requires topics to be in consecutive order.

This means revup is able to pull together relative
chains in any arbitrary order, as long as that order
is valid with no cycles.

Fixes: #156