### PR TITLE
upload: Split populate reviews into 2 phases

### DIFF
--- a/revup/upload.py
+++ b/revup/upload.py
@@ -34,13 +34,15 @@ async def main(
             raise_on_invalid=True,
         )
         await topics.populate_reviews(
-            args.uploader if args.uploader else git_ctx.author,
             force_relative_chain=args.relative_chain,
             labels=args.labels,
             user_aliases=args.user_aliases,
             auto_add_users=args.auto_add_users,
             self_authored_only=args.self_authored_only,
             limit_topics=args.topics,
+        )
+        await topics.populate_relative_reviews(
+            args.uploader if args.uploader else git_ctx.author,
         )
 
     if not args.dry_run:


### PR DESCRIPTION
This sets the function up to allow arbitrary topic
order in the future.

The first pass handles finding the relative topic, but
does not assume it's already populated. The second pass
needs to assume that the relative is already populated
since it uses it, so it needs to be done in topological
order (which is a followup pr).