### PR TITLE
restack: Be topological and update docs

### DIFF
--- a/docs/restack.md
+++ b/docs/restack.md
@@ -12,10 +12,10 @@ revup restack - Reorder commits to group topics together.
 
 Parse commits up to the base branch and group them into topics.
 First apply all commits without a topic in the order they appear.
-Then apply all commits in each topic in the order they appear in
-the topic, in the order each topic appears. The resulting reordered
-commit stack will have topics grouped together to make it more
-convenient to view history and perform interactive rebases.
+Then apply all commits in each topic in topological order, placing
+all topics after (although not necessarily immediately after) any
+topic they are relative to. The resulting stack will be grouped to
+make it more convenient to view history and perform interactive rebases.
 
 Any empty commit without topics, and any topics consisting only
 of empty commits are dropped. An empty commit that is part of
@@ -24,9 +24,9 @@ a topic that has nonempty commits is not dropped.
 The cache and working directory are never modified regardless
 of whether the command succeeds or fails.
 
-Currently, conflicts between commits aren't handled. If any conflict
-arises, the conflicting file paths will be printed and the program will
-exit without making any changes.
+If any conflict arises, the conflicting file paths and conflict markers
+will be printed, and the conflicts will need to be fixed manually by
+adjusting relative topics.
 
 See the help page for **revup upload** for a description of how topic
 tags are parsed.

--- a/revup/restack.py
+++ b/revup/restack.py
@@ -16,6 +16,6 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
     )
 
     await topics.populate_topics()
-
+    await topics.populate_reviews()
     await topics.restack(args.topicless_last)
     return 0

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -1280,7 +1280,7 @@ class TopicStack:
         in a single topic consolidated together.
         """
         to_pick = []
-        for topic in self.topics.values():
+        for _, topic in self.topological_topics():
             this_topic = []
             topic_is_empty = True
             for commit in topic.original_commits:


### PR DESCRIPTION
Restack will now topologically reorder your relative
graph to be linear again. Update docs to reflect this
and the conflict handling.