### PR TITLE
upload: Add "branch-format" config option and commit tag

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -74,6 +74,13 @@ multiple users to collaborate on the same PR. If uploader is specified, all
 relative topics must specify the same uploader. However a topic without a
 specified uploader can still be relative to a topic with one.
 
+**Branch-Format:**
+: Specifies how the remote branches get named, which mainly affects how names
+conflict. Default is "user+branch", which never conflicts, but does not allow
+retargeting a PR to a different base branch. "user" will allow retargeting, but
+will not allow multiple base branches. "branch" and "none" are also supported.
+This tag takes precedence over the config option.
+
 **Relative-Branch:**
 : Optionally specifies a relative branch that this review is targeted against.
 A relative branch is one that represents another user's work or PR, and is
@@ -118,9 +125,12 @@ branch as the base. See above section for definition of a base branch.
 definition of a relative branch.
 
 **--uploader**
-: Used as the username for naming remote branches. The branch syntax
-is {uploader}/revup/{basebranch}/{topic}. If not set value is taken
+: Used as the username for naming remote branches. If not set value is taken
 from the portion of "git config user.email" before the "@".
+
+**--branch-format**
+: Specify how branches are named. See the Branch-Format: tag section for
+options and their meaning.
 
 **--rebase, -r**
 : By default revup will not push changes if local commits are a pure

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -272,6 +272,9 @@ async def main() -> int:
         "--user-aliases",
     )
     upload_parser.add_argument("--uploader")
+    upload_parser.add_argument(
+        "--branch-format", choices=["user+branch", "user", "branch", "none"], default="user+branch"
+    )
     upload_parser.add_argument("--pre-upload", "-p")
     upload_parser.add_argument("--relative-chain", "-c", action="store_true")
     upload_parser.add_argument("--auto-topic", "-a", action="store_true")

--- a/revup/upload.py
+++ b/revup/upload.py
@@ -43,6 +43,7 @@ async def main(
         )
         await topics.populate_relative_reviews(
             args.uploader if args.uploader else git_ctx.author,
+            branch_format=args.branch_format,
         )
 
     if not args.dry_run:


### PR DESCRIPTION
Branch-format will let you control how branches are named,
which has an effect on when branches collide. This can be
set on cmdline, from config file, or on a topic-by-topic
basis inside the commit text.

user+branch is the default today and will remain the default.
Branch names will never collide if using this, but you cannot
retarget to other base branches, and you must use Uploader: if
another user wants to push to this branch.

user allows retargeting prs to other base branches, but will
not allow multiple base-branches to be specified. if they are,
it will warn to specify user+branch instead.

branch will allow others to upload to the same pr, but uploader:
cannot be used.

none includes both limitations and features of user and branch.

I don't really believe there's good use cases for branch and none,
but i'm implementing them to be complete.

Fixes: #11