### PR TITLE
amend: Correctly strip comments with no trailing newline

### DIFF
--- a/revup/amend.py
+++ b/revup/amend.py
@@ -66,7 +66,7 @@ async def invoke_editor_for_commit_msg(
 
     if cleanup_type == "strip":
         # Strip out comment lines
-        msg = re.sub(r"^{}.*$\n".format(comment_char), "", msg, flags=re.M)
+        msg = re.sub(r"^{}.*$\n?".format(comment_char), "", msg, flags=re.M)
     elif cleanup_type == "scissors":
         msg = msg.split(f"{comment_char} {CLEANUP_SCISSOR_LINE}")[0]
 


### PR DESCRIPTION
Revup's default COMMIT_EDITMSG does not have a trailing newline; as a
result, the regex used for matching comment lines when cleanup_type is
'strip' will not match the last line in the message and can leave a
trailing comment line. Fix this by making the trailing newline
optional in the regex.

Fixes: 24012d1 ("amend: respect git config commit.cleanup")
Signed-off-by: Brian Kubisiak <brian@kubisiak.com>