### PR TITLE
credential: Remove leading slash before path

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -827,6 +827,7 @@ class Credential:
 
     async def _run(self, subcommand: str, args: Dict[str, str]) -> Dict[str, str]:
         input_str = "\n".join(f"{k}={v}" for k, v in args.items())
+        logging.debug("credential input:\n{}".format(input_str))
         stdout_str = await self.git_ctx.git_stdout("credential", subcommand, input_str=input_str)
         stdout_dict = {}
         for line in stdout_str.splitlines():

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -203,7 +203,7 @@ async def github_connection(
         args.github_oauth = await git_ctx.credential(
             protocol="https",
             host=args.github_url,
-            path=f"/{fork_info.owner}/{fork_info.name}.git",
+            path=f"{fork_info.owner}/{fork_info.name}.git",
         )
         if args.github_oauth != "":
             logging.debug("Used credential from git-credential")


### PR DESCRIPTION
The slash is incorrect according to https://github.com/Skydio/revup/pull/131#discussion_r1548896688

"The leading "/" here is incorrect btw, and fails for credential helpers
that do naive string matching on URL path 😞. It should be just
path=f"{fork_info.owner}/{fork_info.name}.git""