### PR TITLE
git: Properly redact oauth from git credential

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -828,7 +828,9 @@ class Credential:
     async def _run(self, subcommand: str, args: Dict[str, str]) -> Dict[str, str]:
         input_str = "\n".join(f"{k}={v}" for k, v in args.items())
         logging.debug("credential input:\n{}".format(input_str))
-        stdout_str = await self.git_ctx.git_stdout("credential", subcommand, input_str=input_str)
+        stdout_str = await self.git_ctx.git_stdout(
+            "credential", subcommand, input_str=input_str, quiet=True
+        )
         stdout_dict = {}
         for line in stdout_str.splitlines():
             if line == "":

--- a/revup/logs.py
+++ b/revup/logs.py
@@ -72,3 +72,10 @@ def configure_logger(debug: bool, redactions: Dict[str, str]) -> None:
     root_logger = logging.getLogger()
     root_logger.addHandler(handler)
     root_logger.setLevel(logging.DEBUG if debug else logging.INFO)
+
+
+def redact(redactions: Dict[str, str]) -> None:
+    log_filter = logging.getLogger().handlers[0].filters[0]
+    assert isinstance(log_filter, RedactingFilter)
+    for k, v in redactions.items():
+        log_filter.redact(k, v)

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -206,7 +206,8 @@ async def github_connection(
             path=f"{fork_info.owner}/{fork_info.name}.git",
         )
         if args.github_oauth != "":
-            logging.debug("Used credential from git-credential")
+            logs.redact({args.github_oauth: "<GITHUB_OAUTH>"})
+            logging.debug("Used credential from git-credential {}".format(args.github_oauth))
 
     if not args.github_oauth:
         raise RevupUsageException(


### PR DESCRIPTION
This ensures that the token is not printed to stdout
even when using verbose, either with the stdout of the
git operation, or thereafter.