### PR TITLE
upload: Fix review graph comment

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -1232,9 +1232,10 @@ class TopicStack:
                 continue
             review_title = review.pr_update.title or review.pr_info.title
             review_graph_text = REVIEW_GRAPH_FIRST_LINE + (
-                review_graph[review.remote_head][0]
-                .replace(f"{review.pr_info.url}", f"**{review.pr_info.url}**")
-                .replace(f"{review_title}", f"**{review_title}**")
+                review_graph[review.remote_head][0].replace(
+                    f"{review.pr_info.url} {review_title}",
+                    f"**{review.pr_info.url} {review_title}**",
+                )
             )
             if len(review.pr_info.comments) > review.review_graph_index:
                 if review_graph_text != review.pr_info.comments[review.review_graph_index].text:


### PR DESCRIPTION
If there are two PRs in a relative chain where one PR's URL is a
prefix of another (e.g. when PR 24 is relative to PR 2), the review
graph comment will incorrectly modify the second URL by inserting '**'
at the start and in the middle of the URL. This is due to the naive
string replacement checking for any occurance of each URL.

Fix this by searching instead for the URL followed by the review title
and replacing them both at once instead of individually. This is also
slightly more efficient since there are fewer strings allocated.

Signed-off-by: Brian Kubisiak <brian@kubisiak.com>