### PR TITLE
upload: Add a --push-only flag

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -6,7 +6,7 @@ revup upload - Modify or create code reviews.
 
 `revup [--verbose] [--keep-temp]`
 : `upload [--help] [--base-branch=<br>] [--relative-branch=<br>]`
-`[--rebase] [--relative-chain] [--skip-confirm] [--dry-run]`
+`[--rebase] [--relative-chain] [--skip-confirm] [--dry-run] [--push-only]`
 `[--status] [--no-cherry-pick] [--no-update-pr-body] [--review-graph]`
 `[--trim-tags] [--create-local-branches] [--patchsets] [--auto-add-users=<o>]`
 `[--labels=<labels>] [<topics>]`
@@ -161,6 +161,10 @@ customized to ensure lint checks pass before uploading.
 github. This means that changes are still cherry-picked if necessary, and
 the command can still fail if there are conflicts. This will also skip the
 confirmation step and only print topic info.
+
+**--push-only, -p**
+: Like --dry-run except this also pushes branches to the git remote, but
+does not issue any github queries or attempt rebase detection.
 
 **--status, -t**
 : Print out status info of pull requests for existing topics but don't attempt

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -258,6 +258,7 @@ async def main() -> int:
     upload_parser.add_argument("--rebase", "-r", action="store_true")
     upload_parser.add_argument("--skip-confirm", "-s", action="store_true")
     upload_parser.add_argument("--dry-run", "-d", action="store_true")
+    upload_parser.add_argument("--push-only", action="store_true")
     upload_parser.add_argument("--status", "-t", action="store_true")
     upload_parser.add_argument("--update-pr-body", action="store_true", default=True)
     upload_parser.add_argument("--create-local-branches", action="store_true")


### PR DESCRIPTION
This is similar to to dry-run except it will also push your
branches for you. This can be used to either create PRS manually
in github or with other code review backends that we haven't integrated
yet.

Topic: ponly
Fixes: #179