### PR TITLE
git: Bump git supported version to 2.43

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Revup provides command-line tools that allow developers to iterate faster on par
 
 # Compatibility
 
-Revup requires python 3.8 or higher and git 2.40 or higher. Revup works with Linux, OSX, and Windows (limited testing).
+Revup requires python 3.8 or higher and git 2.43 or higher. Revup works with Linux, OSX, and Windows (limited testing).
 
 Follow instructions [here](https://git-scm.com/downloads) to get the latest git version for your OS. Revup uses flags only present in newer git versions.
 

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -105,7 +105,7 @@ def make_toplevel_parser() -> RevupArgParser:
     revup_parser.add_argument("--git-path", default="")
     revup_parser.add_argument("--main-branch", default="main")
     revup_parser.add_argument("--base-branch-globs", default="")
-    revup_parser.add_argument("--git-version", default="2.39.0")
+    revup_parser.add_argument("--git-version", default="2.43.0")
     return revup_parser
 
 


### PR DESCRIPTION
This gets us access to the --merge-base and -X flags to
"git merge-tree"

Topic: gitv