### PR TITLE
git: Correctly bump git version to 2.40

### DIFF
--- a/revup/revup.py
+++ b/revup/revup.py
@@ -105,7 +105,7 @@ def make_toplevel_parser() -> RevupArgParser:
     revup_parser.add_argument("--git-path", default="")
     revup_parser.add_argument("--main-branch", default="main")
     revup_parser.add_argument("--base-branch-globs", default="")
-    revup_parser.add_argument("--git-version", default="2.39.0")
+    revup_parser.add_argument("--git-version", default="2.40.0")
     return revup_parser
 
 


### PR DESCRIPTION
2.40 is specified in the README but we were only enforcing
2.39, which was missing some flags to merge-tree.

Topic: gitv1