### PR TITLE
amend: Allow amending with pure renames

### DIFF
--- a/revup/amend.py
+++ b/revup/amend.py
@@ -138,10 +138,10 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
     """
 
     async def get_has_unstaged() -> bool:
-        return args.all and await git_ctx.git_return_code("diff", "--quiet") != 0
+        return args.all and await git_ctx.git_return_code("diff", "--no-renames", "--quiet") != 0
 
     has_staged, has_unstaged = await asyncio.gather(
-        git_ctx.git_return_code("diff", "--cached", "--quiet"),
+        git_ctx.git_return_code("diff", "--cached", "--no-renames", "--quiet"),
         get_has_unstaged(),
     )
 


### PR DESCRIPTION
If the only staged changes are pure renames, 'git diff --cached
--quiet' will not report any changes. As a result, attempting to
'revup amend' would skip writing a new tree for the commit and the
rename would still be staged rather than added to the amended commit.

Fix this by turning off rename detection when checking for staged
changes in 'revup amend'. This should be slightly more efficient as
well.

Signed-off-by: Brian Kubisiak <brian@kubisiak.com>