### PR TITLE
git: Correctly match repository names containing '.'

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -300,13 +300,13 @@ class Git:
             return GitHubRepoInfo(owner=owner, name=name)
         remote_url = ret[1]
         while True:
-            match = rf"^[^@]+@{github_url}:([^/]+)/([^.]+)(?:\.git)?$"
+            match = rf"^[^@]+@{github_url}:([^/]+)/(.+)(?<!\.git)(?:\.git)?$"
             m = re.match(match, remote_url)
             if m:
                 owner = m.group(1)
                 name = m.group(2)
                 break
-            search = rf"{github_url}/([^/]+)/([^.]+)"
+            search = rf"{github_url}/([^/]+)/(.+)(?<!\.git)(?:\.git)?$"
             m = re.search(search, remote_url)
             if m:
                 owner = m.group(1)


### PR DESCRIPTION
The '.' character is valid in repository names on github. Change the
regexes to use negative lookbehind assertions to avoid matching an
optional trailing '.git' instead of stopping the repository name when
encountering '.'.

Without this, revup cannot be used on repositories containing the '.'
character.

Signed-off-by: Brian Kubisiak <brian@kubisiak.com>