### PR TITLE
docs: improve GitHub token setup instructions for better accessibility and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Creating test PRs can be spammy so don't do the tutorial on other people's repos
 git clone https://github.com/<your-name>/revup.git && cd revup
 ```
 
-On first run, you will need to configure github credentials. Create a personal access token [here](https://github.com/settings/tokens/new)
-and check the box for "full repo permissions". Revup needs this in order to create and modify pull requests. Then run
+On first run, you will need to configure github credentials. Create a [GitHub Personal Access Token](https://github.com/settings/tokens/new?scopes=repo)
+with "repo" scope. Revup needs this in order to create and modify pull requests. Then run
 ```sh
 revup config github_oauth
 ```


### PR DESCRIPTION
This PR improves the GitHub Personal Access Token setup instructions in the README to enhance accessibility and user experience.

Changes:
- Replace generic "here" link text with more descriptive "GitHub Personal Access Token" for better accessibility
- Add `?scopes=repo` query parameter to pre-select required permissions
- Update permission description from "full repo permissions" to more accurate "repo" scope

<img width="400" alt="github setting page" src="https://github.com/user-attachments/assets/5b35562b-963e-42cf-90f9-2a8d9bbadc6b">
