### PR TITLE
git: Don't swallow all push output

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -1029,7 +1029,15 @@ class TopicStack:
                 self.git_ctx.remote_name,
                 *push_targets,
             ]
-            await self.git_ctx.git(*push_args, stderr=subprocess.PIPE)
+            await self.git_ctx.git(
+                *push_args,
+                stdout=subprocess.STDOUT,
+                stderr=subprocess.STDOUT,
+                # Hide the remote output that says "Create a pull request for '' on GitHub"
+                output_transform=lambda l: (
+                    b"" if (l.startswith(b"remote: ") and self.git_ctx.sh.quiet) else l
+                ),
+            )
 
     async def query_github(self) -> None:
         """


### PR DESCRIPTION
In certain situations "git push" will need to auth interactively. However
we don't show the user any output from git push because of github's automatic
"create a pr test" that is generally not what we want since revup handles pr
creation. This does make these auth situations confusing though.

Instead of hiding all output, default to showing output except for lines prefixed
with "remote:" which will get hidden.

Topic: outpush3
Closes: #33
Reviewers: aaron, brian-k