### PR TITLE
upload: Check PRs merge into base branch rather than base ref

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -743,11 +743,11 @@ class TopicStack:
             if (
                 review.status == PrStatus.MERGED
                 and review.pr_info is not None
-                and review.remote_base != review.pr_info.baseRef
+                and self.git_ctx.remove_branch_prefix(base_branch) != review.pr_info.baseRef
             ):
                 logging.warning(
                     f"Branch {review.remote_head} was merged into {review.pr_info.baseRef} "
-                    f"instead of {review.remote_base} as expected!"
+                    f"instead of {base_branch} as expected!"
                 )
                 # NOTE: This may not iteract well with the check at the end of create_commits
                 # but they are both corner cases and the worst that could happen is we fail to


### PR DESCRIPTION
The logic for checking whether a PR was improperly merged was allowing
the target branch name, which could be a relative branch. We don't want
that, we only want changes to merge into the base branch of the entire chain.

This also helps handle some reordering issues.

Topic: reorder3
Reviewers: aaron, brian-k