### PR TITLE
Use raw remote URL to parse GitHub repo info

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -311,7 +311,7 @@ class Git:
         """
         owner = ""
         name = ""
-        ret = await self.git("remote", "get-url", remote_name, raiseonerror=False)
+        ret = await self.git("config", "--get", f"remote.{remote_name}.url", raiseonerror=False)
         if ret[0] != 0:
             return GitHubRepoInfo(owner=owner, name=name)
         remote_url = ret[1]


### PR DESCRIPTION
## Summary

`git remote get-url` applies `url.*.insteadOf` rewriting before returning the URL. If a user has configured `insteadOf` rules that rewrite the hostname (e.g. to route through a custom SSH host alias), the returned URL no longer contains "github.com" and revup fails to extract the repo owner and name.

This changes `get_github_repo_info` to use `git config --get remote.<name>.url` instead, which reads the URL exactly as stored in the repo config before any rewriting is applied. The stored URL is what the user originally configured to point at GitHub, so it will always be parseable. The `insteadOf` rewriting still takes effect for all actual git operations (fetch, push, etc.) since those go through the normal git remote machinery.