### PR TITLE
man: Fix double-hyphen rendering in man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ man:
 	for file in *.md ; do \
 		CMD_NAME=`echo $${file} | awk -F'[.]' '{print $$1}'` ; \
 		echo "$${REVUP_HEADER}" | m4 -DTITLE=$${CMD_NAME} -DVERSION=$(REVUP_VERSION) -DDATE="$(REVUP_DATE)" - | \
-		cat - $${file} | pandoc -s -t man > ../revup/man1/$${CMD_NAME}.1 || exit 1 ; \
+		cat - $${file} | pandoc -f markdown-smart -s -t man > ../revup/man1/$${CMD_NAME}.1 || exit 1 ; \
 		gzip -n -f -k ../revup/man1/$${CMD_NAME}.1 || exit 1 ; \
 	done
 


### PR DESCRIPTION
Pandoc's default smart typography converts `--` to en-dashes, making
long options like `--verbose` uncopyable from man page output. Disable
the smart extension with `-f markdown-smart` so option hyphens render
as literal hyphen-minus characters.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Topic: man