### PR TITLE
Fix deprecated asyncio functions

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -19,7 +19,8 @@ def _main() -> None:
         # https://stackoverflow.com/questions/63860576/asyncio-event-loop-is-closed-when-using-asyncio-run
         # Since revup makes use of subprocess, we can't use WindowsSelectorEventLoopPolicy.
         # Instead, we can manually create the event loop and prevent the RuntimeError on shutdown.
-        sys.exit(asyncio.get_event_loop().run_until_complete(main()))
+        loop = asyncio.new_event_loop()
+        sys.exit(loop.run_until_complete(main()))
     except RevupUsageException as e:
         logging.error(str(e))
         sys.exit(2)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -22,10 +22,7 @@ def mock_revup(args, user_input) -> str:
     with mock.patch.object(sys, "argv", args):
         with mock.patch.object(builtins, "input", lambda x: user_input.pop(0)):
             with mock.patch("sys.stdout", new_callable=io.StringIO):
-                # Ensure we finish main.
-                loop = asyncio.get_event_loop()
-                coroutine = revup.main()
-                loop.run_until_complete(coroutine)
+                asyncio.run(revup.main())
                 output = sys.stdout.getvalue()
 
     # This is the stdout output.


### PR DESCRIPTION
Replaced the deprecated asyncio.get_event_loop().run_until_complete() with asyncio.run().

Fixes the help menu test and the runtime warnings under python 3.11.