### PR TITLE
docs: Fix out of date man pages

### DIFF
--- a/docs/amend.md
+++ b/docs/amend.md
@@ -5,7 +5,9 @@ revup amend - Modify commits in the current stack.
 # SYNOPSIS
 
 `revup [--verbose] [--keep-temp]`
-: `amend [--help] [--no-edit] [--all] <ref|topic>`
+: `amend [--help] [--edit] [--insert] [--drop] [--all]`
+`[--base-branch=<br>] [--relative-branch=<br>]`
+`[--no-parse-topics] [--no-parse-refs] [<ref|topic>]`
 
 # DESCRIPTION
 
@@ -43,9 +45,9 @@ ancestor of the most recent commit of the topic `mytopic`).
 **--help, -h**
 : Show this help page.
 
-**--no-edit**
-: Don't open up an editor to edit the commit message and instead
-use the old commit message as-is.
+**--edit, -s**
+: Open an editor to edit the commit message. Enabled by default.
+Use --no-edit to skip editing and keep the old commit message as-is.
 
 **--insert, -i**
 : Instead of amending the given commit, insert the changes in cache

--- a/docs/restack.md
+++ b/docs/restack.md
@@ -5,8 +5,8 @@ revup restack - Reorder commits to group topics together.
 # SYNOPSIS
 
 `revup [--verbose] [--keep-temp]`
-: `restack [--help] [--base-branch=<base>] [--num-commits=<N>]`
-`[--relative-chain]`
+: `restack [--help] [--base-branch=<base>] [--relative-branch=<br>]`
+`[--topicless-last]`
 
 # DESCRIPTION
 
@@ -40,10 +40,9 @@ tags are parsed.
 : Instead of automatically detecting the base branch, use the given
 branch as the base.
 
-**--relative-chain, -r**
-: Ignore all relative topic tags and instead act as though each topic is
-relative to the topic before it. This can save effort typing out relative
-tags when you know all reviews in the stack will be dependent.
+**--relative-branch, -e**
+: Use the given branch as the relative branch. See `revup upload -h`
+for the definition of a relative branch.
 
 **--topicless-last, -t**
 : Apply all topicless commits last (at the top of the commit stack) instead

--- a/docs/revup.md
+++ b/docs/revup.md
@@ -30,6 +30,9 @@ graphql requests to github.
 **--help, -h**
 : Show this help page.
 
+**--version**
+: Print the version of revup and exit.
+
 **--proxy**
 : Proxy to use when making connections to GitHub
 

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -7,7 +7,7 @@ revup upload - Modify or create code reviews.
 `revup [--verbose] [--keep-temp]`
 : `upload [--help] [--base-branch=<br>] [--relative-branch=<br>]`
 `[--rebase] [--relative-chain] [--skip-confirm] [--dry-run] [--push-only]`
-`[--status] [--no-cherry-pick] [--no-update-pr-body] [--review-graph]`
+`[--status] [--no-update-pr-body] [--review-graph]`
 `[--trim-tags] [--create-local-branches] [--patchsets] [--auto-add-users=<o>]`
 `[--labels=<labels>] [<topics>]`
 
@@ -151,7 +151,7 @@ and PR creation, but changes to the commit title may change the PR branch.
 : Don't require the user to confirm before uploading to github. Also skips
 printing topic info before the upload.
 
-**--pre-upload**
+**--pre-upload, -p**
 : A shell command that will be run before uploading any reviews.
 Upload will fail with error status if this command fails. Can be
 customized to ensure lint checks pass before uploading.
@@ -162,7 +162,7 @@ github. This means that changes are still cherry-picked if necessary, and
 the command can still fail if there are conflicts. This will also skip the
 confirmation step and only print topic info.
 
-**--push-only, -p**
+**--push-only**
 : Like --dry-run except this also pushes branches to the git remote, but
 does not issue any github queries or attempt rebase detection.
 


### PR DESCRIPTION
restack.md:
  - Removed --num-commits=<N> from synopsis (doesn't exist in code)
  - Removed --relative-chain from synopsis and options (not on restack, only upload)
  - Added --relative-branch, -e which exists but was undocumented

  upload.md:
  - Removed --no-cherry-pick from synopsis (doesn't exist in code)
  - Removed -p short form from --push-only (it has no short form)
  - Added -p short form to --pre-upload (which has it in code)

  amend.md:
  - Expanded synopsis to include all flags: --insert, --drop, --base-branch, --relative-branch, --no-parse-topics,
  --no-parse-refs
  - Changed --no-edit entry to document as --edit, -s with --no-edit as the negation

  revup.md:
  - Added --version option