### PR TITLE
Fix missing event loop cleanup

### DIFF
--- a/revup/__main__.py
+++ b/revup/__main__.py
@@ -22,7 +22,10 @@ def _main() -> None:
         # Instead, we can manually create the event loop and prevent the RuntimeError on shutdown.
         revup_parser, all_parsers = build_parser()
         loop = asyncio.new_event_loop()
-        sys.exit(loop.run_until_complete(main(revup_parser, all_parsers)))
+        try:
+            sys.exit(loop.run_until_complete(main(revup_parser, all_parsers)))
+        finally:
+            loop.close()
     except RevupUsageException as e:
         logging.error(str(e))
         sys.exit(2)


### PR DESCRIPTION
Prevents a stacktrace if we hit an exception

Exception ignored in: <function BaseEventLoop.__del__ at 0x7ff9244263a0>
Traceback (most recent call last):
  File "/usr/lib/python3.8/asyncio/base_events.py", line 656, in __del__
    self.close()
  File "/usr/lib/python3.8/asyncio/unix_events.py", line 58, in close
    super().close()
  File "/usr/lib/python3.8/asyncio/selector_events.py", line 92, in close
    self._close_self_pipe()
  File "/usr/lib/python3.8/asyncio/selector_events.py", line 99, in _close_self_pipe
    self._remove_reader(self._ssock.fileno())
  File "/usr/lib/python3.8/asyncio/selector_events.py", line 276, in _remove_reader
    key = self._selector.get_key(fd)
  File "/usr/lib/python3.8/selectors.py", line 190, in get_key
    return mapping[fileobj]
  File "/usr/lib/python3.8/selectors.py", line 71, in __getitem__
    fd = self._selector._fileobj_lookup(fileobj)
  File "/usr/lib/python3.8/selectors.py", line 225, in _fileobj_lookup
    return _fileobj_to_fd(fileobj)
  File "/usr/lib/python3.8/selectors.py", line 42, in _fileobj_to_fd
    raise ValueError("Invalid file descriptor: {}".format(fd))
ValueError: Invalid file descriptor: -1