### PR TITLE
restack: Add the --squash flag and tests

### DIFF
--- a/docs/restack.md
+++ b/docs/restack.md
@@ -6,7 +6,7 @@ revup restack - Reorder commits to group topics together.
 
 `revup [--verbose] [--keep-temp]`
 : `restack [--help] [--base-branch=<base>] [--relative-branch=<br>]`
-`[--topicless-last]`
+`[--topicless-last] [--squash]`
 
 # DESCRIPTION
 
@@ -47,3 +47,7 @@ for the definition of a relative branch.
 **--topicless-last, -t**
 : Apply all topicless commits last (at the top of the commit stack) instead
 of first.
+
+**--squash, -s**
+: Squash all commits within each topic into a single commit. Commit messages
+are merged and duplicate revup tags are combined.

--- a/revup/restack.py
+++ b/revup/restack.py
@@ -1,6 +1,162 @@
 import argparse
+import copy
+from collections import defaultdict
+from typing import Dict, List, Optional, Set, Tuple
 
 from revup import git, topic_stack
+from revup.topic_stack import (
+    TAG_ASSIGNEE,
+    TAG_BRANCH,
+    TAG_BRANCH_FORMAT,
+    TAG_LABEL,
+    TAG_RELATIVE,
+    TAG_RELATIVE_BRANCH,
+    TAG_REVIEWER,
+    TAG_TOPIC,
+    TAG_UPDATE_PR_BODY,
+    TAG_UPLOADER,
+    TopicStack,
+    add_tags,
+)
+from revup.types import (
+    GitCommitHash,
+    GitConflictException,
+    GitTreeHash,
+    RevupConflictException,
+)
+
+TAG_ORDER = [
+    TAG_TOPIC,
+    TAG_RELATIVE,
+    TAG_RELATIVE_BRANCH,
+    TAG_BRANCH,
+    TAG_REVIEWER,
+    TAG_ASSIGNEE,
+    TAG_LABEL,
+    TAG_UPLOADER,
+    TAG_UPDATE_PR_BODY,
+    TAG_BRANCH_FORMAT,
+]
+
+
+def merge_commit_messages(topics: TopicStack, commits: List[git.CommitHeader]) -> str:
+    all_tags: Dict[str, Set[str]] = defaultdict(set)
+    bodies: List[str] = []
+
+    for commit in commits:
+        tags, trimmed = topics.parse_commit_tags(commit.commit_msg)
+        add_tags(all_tags, tags)
+        if trimmed:
+            bodies.append(trimmed)
+
+    merged = "\n\n".join(bodies)
+
+    tag_lines = []
+    for tag in TAG_ORDER:
+        if tag in all_tags:
+            tag_lines.append(f"{tag.capitalize()}: {', '.join(sorted(all_tags[tag]))}")
+    if tag_lines:
+        merged += "\n\n" + "\n".join(tag_lines)
+
+    return merged
+
+
+async def squash_topics(
+    topics: TopicStack,
+    head: GitCommitHash,
+    to_restack: List[git.CommitHeader],
+) -> GitCommitHash:
+    topic_commit_groups: List[Tuple[str, List[git.CommitHeader]]] = []
+    current_name: Optional[str] = None
+    current_group: List[git.CommitHeader] = []
+
+    for commit in to_restack:
+        name = None
+        for topic_name, topic in topics.topics.items():
+            if commit in topic.original_commits:
+                name = topic_name
+                break
+
+        if name != current_name:
+            if current_group:
+                topic_commit_groups.append((current_name or "", current_group))
+            current_name = name
+            current_group = [commit]
+        else:
+            current_group.append(commit)
+    if current_group:
+        topic_commit_groups.append((current_name or "", current_group))
+
+    base = await topics.git_ctx.git_stdout("rev-parse", f"{head}~{len(to_restack)}")
+    new_parent = GitCommitHash(base)
+
+    for name, group in topic_commit_groups:
+        if len(group) <= 1 or name == "":
+            for commit in group:
+                new_parent = await topics.git_ctx.synthetic_cherry_pick_from_commit(
+                    commit, new_parent
+                )
+        else:
+            pick_parent = new_parent
+            for commit in group:
+                pick_parent = await topics.git_ctx.synthetic_cherry_pick_from_commit(
+                    commit, pick_parent
+                )
+            squashed = copy.deepcopy(group[0])
+            squashed.tree = GitTreeHash(
+                await topics.git_ctx.git_stdout("rev-parse", f"{pick_parent}^{{tree}}")
+            )
+            squashed.parents = [new_parent]
+            squashed.commit_msg = merge_commit_messages(topics, group)
+            new_parent = await topics.git_ctx.commit_tree(squashed)
+
+    return new_parent
+
+
+async def restack(topics: TopicStack, topicless_last: bool, squash: bool = False) -> GitCommitHash:
+    to_pick = []
+    for _, topic in topics.topological_topics():
+        this_topic = []
+        topic_is_empty = True
+        for commit in topic.original_commits:
+            this_topic.append(commit)
+            if not await topics.git_ctx.have_identical_trees(commit.commit_id, commit.parents[0]):
+                topic_is_empty = False
+        # Drop empty topics, ie topics with all empty commits. git pull --rebase
+        # doesn't automatically drop empty commits if they're been merged.
+        if not topic_is_empty:
+            to_pick.extend(this_topic)
+    no_topic = []
+    for commit in topics.commits:
+        if commit not in to_pick and not await topics.git_ctx.have_identical_trees(
+            commit.commit_id, commit.parents[0]
+        ):
+            no_topic.append(commit)
+
+    new_parent = topics.commits[0].parents[0]
+    if topicless_last:
+        to_restack = to_pick + no_topic
+    else:
+        to_restack = no_topic + to_pick
+    for commit in to_restack:
+        try:
+            new_parent = await topics.git_ctx.synthetic_cherry_pick_from_commit(commit, new_parent)
+        except GitConflictException as exc:
+            await topics.git_ctx.dump_conflict(exc)
+            raise RevupConflictException(
+                commit,
+                new_parent,
+                "You may need to `git rebase -i` to resolve these conflicts!",
+            ) from exc
+
+    if squash:
+        new_parent = await squash_topics(topics, new_parent, to_restack)
+
+    git_env = {
+        "GIT_REFLOG_ACTION": "reset --soft (revup restack)",
+    }
+    await topics.git_ctx.soft_reset(new_parent, git_env)
+    return new_parent
 
 
 async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
@@ -17,5 +173,5 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
 
     await topics.populate_topics()
     await topics.populate_reviews()
-    await topics.restack(args.topicless_last)
+    await restack(topics, args.topicless_last, args.squash)
     return 0

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -192,6 +192,7 @@ def build_parser() -> Tuple[RevupArgParser, List[RevupArgParser]]:
     upload_parser.add_argument("--head", default="HEAD")
 
     restack_parser.add_argument("--topicless-last", "-t", action="store_true")
+    restack_parser.add_argument("--squash", "-s", action="store_true")
 
     ref_or_topic_arg = amend_parser.add_argument("ref_or_topic", nargs="?")
     ref_or_topic_arg.completer = topic_completer  # type: ignore[attr-defined]

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -1366,53 +1366,6 @@ class TopicStack:
         if prs_to_update:
             await github_utils.update_pull_requests(self.github_ep, prs_to_update)
 
-    async def restack(self, topicless_last: bool) -> GitCommitHash:
-        """
-        Create a new commit chain consisting of current commits but with commits
-        in a single topic consolidated together.
-        """
-        to_pick = []
-        for _, topic in self.topological_topics():
-            this_topic = []
-            topic_is_empty = True
-            for commit in topic.original_commits:
-                this_topic.append(commit)
-                if not await self.git_ctx.have_identical_trees(commit.commit_id, commit.parents[0]):
-                    topic_is_empty = False
-            # Drop empty topics, ie topics with all empty commits. git pull --rebase
-            # doesn't automatically drop empty commits if they're been merged.
-            if not topic_is_empty:
-                to_pick.extend(this_topic)
-        no_topic = []
-        for commit in self.commits:
-            if commit not in to_pick and not await self.git_ctx.have_identical_trees(
-                commit.commit_id, commit.parents[0]
-            ):
-                no_topic.append(commit)
-
-        new_parent = self.commits[0].parents[0]
-        if topicless_last:
-            to_restack = to_pick + no_topic
-        else:
-            to_restack = no_topic + to_pick
-        for commit in to_restack:
-            try:
-                new_parent = await self.git_ctx.synthetic_cherry_pick_from_commit(
-                    commit, new_parent
-                )
-            except GitConflictException as exc:
-                await self.git_ctx.dump_conflict(exc)
-                raise RevupConflictException(
-                    commit,
-                    new_parent,
-                    "You may need to `git rebase -i` to resolve these conflicts!",
-                ) from exc
-        git_env = {
-            "GIT_REFLOG_ACTION": "reset --soft (revup restack)",
-        }
-        await self.git_ctx.soft_reset(new_parent, git_env)
-        return new_parent
-
     def num_reviews_changed(self) -> int:
         """
         Return the number of reviews that require some action (push / create / update).

--- a/tests/test_restack.py
+++ b/tests/test_restack.py
@@ -1,0 +1,227 @@
+import pytest
+from git_env import GitTestEnvironment, async_test
+
+from revup.restack import restack
+from revup.topic_stack import TopicStack
+
+
+async def setup_repo(env):
+    await env.commit("root", {"root.txt": "r"})
+    await env.git_ctx.git("branch", "origin/main", "HEAD")
+
+
+async def run_restack(env, topicless_last=False, squash=False):
+    topics = TopicStack(env.git_ctx, None, None)
+    await topics.populate_topics()
+    await topics.populate_reviews()
+    await restack(topics, topicless_last, squash)
+    return topics
+
+
+class TestRestackBasic:
+    @async_test
+    async def test_groups_interleaved_topic_commits(self):
+        """Commits from the same topic should be grouped together."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("a1\n\nTopic: alpha", {"a.txt": "a1"})
+            await env.commit("b1\n\nTopic: beta", {"b.txt": "b1"})
+            await env.commit("a2\n\nTopic: alpha", {"a.txt": "a2"})
+
+            await run_restack(env)
+            subjects = await env.get_log_subjects()
+
+            # Topics are grouped: alpha's commits together, beta's together.
+            # Topological order puts alpha first (bottom), beta on top.
+            assert subjects == ["b1", "a2", "a1", "root"]
+            assert await env.get_file_at_commit("a.txt") == "a2"
+            assert await env.get_file_at_commit("b.txt") == "b1"
+
+    @async_test
+    async def test_noop_when_already_grouped(self):
+        """Restack should be idempotent when topics are already contiguous."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("a1\n\nTopic: alpha", {"a.txt": "a1"})
+            await env.commit("a2\n\nTopic: alpha", {"a.txt": "a2"})
+            await env.commit("b1\n\nTopic: beta", {"b.txt": "b1"})
+            tree_before = await env.get_tree_hash()
+
+            await run_restack(env)
+            tree_after = await env.get_tree_hash()
+
+            assert tree_before == tree_after
+
+
+class TestRestackTopiclessLast:
+    @async_test
+    async def test_topicless_commits_placed_last(self):
+        """With --topicless-last, non-topic commits go to the top of the stack."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("no topic", {"x.txt": "x"})
+            await env.commit("a1\n\nTopic: alpha", {"a.txt": "a"})
+
+            await run_restack(env, topicless_last=True)
+            subjects = await env.get_log_subjects()
+
+            assert subjects == ["no topic", "a1", "root"]
+
+    @async_test
+    async def test_topicless_commits_placed_first_by_default(self):
+        """Without the flag, topicless commits come before topic commits."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("a1\n\nTopic: alpha", {"a.txt": "a"})
+            await env.commit("no topic", {"x.txt": "x"})
+
+            await run_restack(env, topicless_last=False)
+            subjects = await env.get_log_subjects()
+
+            assert subjects == ["a1", "no topic", "root"]
+
+
+class TestRestackDropsEmpty:
+    @async_test
+    async def test_drops_empty_topic(self):
+        """A topic consisting entirely of empty commits should be dropped."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("real\n\nTopic: alpha", {"a.txt": "a"})
+            # Empty commit — same tree as parent
+            await env.commit("empty\n\nTopic: empty_topic")
+
+            await run_restack(env)
+            subjects = await env.get_log_subjects()
+
+            assert "empty" not in subjects
+            assert "real" in subjects
+
+    @async_test
+    async def test_keeps_empty_commit_in_nonempty_topic(self):
+        """An empty commit inside a topic with real changes should be kept."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("real change\n\nTopic: alpha", {"a.txt": "a"})
+            await env.commit("empty followup\n\nTopic: alpha")
+
+            await run_restack(env)
+            subjects = await env.get_log_subjects()
+
+            assert subjects == ["empty followup", "real change", "root"]
+
+
+class TestRestackRelativeTopics:
+    @async_test
+    async def test_relative_topic_ordered_after_parent(self):
+        """A topic relative to another must appear after its parent."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("child\n\nTopic: child\nRelative: parent", {"c.txt": "c"})
+            await env.commit("parent\n\nTopic: parent", {"p.txt": "p"})
+
+            await run_restack(env)
+            subjects = await env.get_log_subjects()
+
+            parent_idx = subjects.index("parent")
+            child_idx = subjects.index("child")
+            assert child_idx < parent_idx  # child is higher (more recent) in the stack
+
+
+class TestRestackSquash:
+    @async_test
+    async def test_squash_multi_commit_topic(self):
+        """--squash should collapse multi-commit topics into one commit."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("a1\n\nTopic: alpha", {"a.txt": "a1"})
+            await env.commit("a2\n\nTopic: alpha", {"a.txt": "a2"})
+            await env.commit("a3\n\nTopic: alpha", {"b.txt": "b"})
+
+            await run_restack(env, squash=True)
+
+            assert await env.get_commit_count() == 2
+            assert await env.get_file_at_commit("a.txt") == "a2"
+            assert await env.get_file_at_commit("b.txt") == "b"
+
+    @async_test
+    async def test_squash_merges_messages(self):
+        """Squashed commit should contain body text from all original commits."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("first title\n\nbody one\n\nTopic: alpha", {"a.txt": "a"})
+            await env.commit("second title\n\nbody two\n\nTopic: alpha", {"b.txt": "b"})
+
+            await run_restack(env, squash=True)
+            msg = await env.get_commit_message()
+
+            assert "first title" in msg
+            assert "body one" in msg
+            assert "second title" in msg
+            assert "body two" in msg
+
+    @async_test
+    async def test_squash_deduplicates_tags(self):
+        """Duplicate reviewers/labels across commits should appear once."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit(
+                "c1\n\nTopic: alpha\nReviewer: alice, bob",
+                {"a.txt": "a"},
+            )
+            await env.commit(
+                "c2\n\nTopic: alpha\nReviewer: bob, carol",
+                {"b.txt": "b"},
+            )
+
+            await run_restack(env, squash=True)
+            msg = await env.get_commit_message()
+
+            assert msg.count("alice") == 1
+            assert msg.count("bob") == 1
+            assert msg.count("carol") == 1
+
+    @async_test
+    async def test_squash_leaves_single_commit_topics_alone(self):
+        """Topics with only one commit shouldn't be affected by squash."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("a\n\nTopic: alpha", {"a.txt": "a"})
+            await env.commit("b\n\nTopic: beta", {"b.txt": "b"})
+            orig_count = await env.get_commit_count()
+
+            await run_restack(env, squash=True)
+
+            assert await env.get_commit_count() == orig_count
+
+    @async_test
+    async def test_squash_preserves_topicless_commits(self):
+        """Topicless commits should not be squashed together."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("no topic 1", {"x.txt": "x"})
+            await env.commit("no topic 2", {"y.txt": "y"})
+            await env.commit("a1\n\nTopic: alpha", {"a.txt": "a1"})
+            await env.commit("a2\n\nTopic: alpha", {"a.txt": "a2"})
+
+            await run_restack(env, squash=True)
+
+            # 1 root + 2 topicless + 1 squashed alpha = 4
+            assert await env.get_commit_count() == 4
+
+    @async_test
+    async def test_squash_with_multiple_topics(self):
+        """Each topic should be independently squashed."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("a1\n\nTopic: alpha", {"a.txt": "a1"})
+            await env.commit("a2\n\nTopic: alpha", {"a.txt": "a2"})
+            await env.commit("b1\n\nTopic: beta", {"b.txt": "b1"})
+            await env.commit("b2\n\nTopic: beta", {"b.txt": "b2"})
+
+            await run_restack(env, squash=True)
+
+            # 1 root + 1 squashed alpha + 1 squashed beta = 3
+            assert await env.get_commit_count() == 3
+            assert await env.get_file_at_commit("a.txt") == "a2"
+            assert await env.get_file_at_commit("b.txt") == "b2"


### PR DESCRIPTION
Makes it easy to squash all commits from one topic together

Fixes: #9