### PR TITLE
upload: Add pr body source argument

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -9,7 +9,7 @@ revup upload - Modify or create code reviews.
 `[--rebase] [--relative-chain] [--skip-confirm] [--dry-run] [--push-only]`
 `[--status] [--no-update-pr-body] [--review-graph]`
 `[--trim-tags] [--create-local-branches] [--patchsets] [--auto-add-users=<o>]`
-`[--force-reviewers] [--labels=<labels>] [<topics>]`
+`[--force-reviewers] [--pr-body-source=<src>] [--labels=<labels>] [<topics>]`
 
 # DESCRIPTION
 
@@ -211,6 +211,13 @@ mappings are used to transform usernames specified in Reviewers/Assignees.
 
 **--force-reviewers**
 : Re-add reviewers and assignees even if they were manually removed from the PR.
+
+**--pr-body-source**
+: Controls where the PR title and body text come from. Options are "first-commit"
+(default), "squashed", or "template". "first-commit" uses the first commit message
+in the topic. "squashed" merges all commit messages in the topic with tags stripped.
+"template" uses the repo's `PULL_REQUEST_TEMPLATE.md` (looked up in `.github/`,
+repo root, or `docs/`) and takes the title from the first commit.
 
 **--auto-add-users**
 : If "no", do nothing extra. If "r2a", add users from the Reviewers tag as assignees.

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -18,6 +18,7 @@ from revup.completion import (
     topic_completer,
 )
 from revup.config import RevupArgParser
+from revup.topic_stack import PrBodySource
 from revup.types import RevupUsageException
 
 REVUP_CONFIG_ENV_VAR = "REVUP_CONFIG_PATH"
@@ -190,6 +191,12 @@ def build_parser() -> Tuple[RevupArgParser, List[RevupArgParser]]:
     upload_parser.add_argument("--relative-chain", "-c", action="store_true")
     upload_parser.add_argument("--auto-topic", "-a", action="store_true")
     upload_parser.add_argument("--force-reviewers", action="store_true")
+    upload_parser.add_argument(
+        "--pr-body-source",
+        type=PrBodySource,
+        choices=PrBodySource,
+        default=PrBodySource.FIRST_COMMIT,
+    )
     upload_parser.add_argument("--head", default="HEAD")
 
     restack_parser.add_argument("--topicless-last", "-t", action="store_true")

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
 from rich import get_console
@@ -92,6 +93,15 @@ def translate_if_exists(names: Set[str], translation: Dict[str, str]) -> Set[str
     Return the translation entry for each name, only if it exists.
     """
     return set(translation[name] for name in names if name in translation)
+
+
+class PrBodySource(Enum):
+    FIRST_COMMIT = "first-commit"
+    SQUASHED = "squashed"
+    TEMPLATE = "template"
+
+    def __str__(self) -> str:
+        return self.value
 
 
 # The current state of each review within github.
@@ -1139,10 +1149,42 @@ class TopicStack:
                 self.relative_infos[pr_targets[i]] = pr_info
             i += 1
 
+    def _get_pr_body_and_title(self, topic: Topic, pr_body_source: PrBodySource) -> Tuple[str, str]:
+        first_msg = topic.original_commits[0].commit_msg
+        title = first_msg.split("\n", 1)[0]
+
+        if pr_body_source == PrBodySource.SQUASHED:
+            bodies = []
+            for commit in topic.original_commits:
+                _, trimmed = self.parse_commit_tags(commit.commit_msg)
+                if trimmed:
+                    bodies.append(trimmed)
+            body = "\n\n".join(bodies)
+            # Use first line of merged text as title, rest as body
+            lines = body.split("\n", 1)
+            title = lines[0]
+            body = lines[1].strip() if len(lines) > 1 else ""
+        elif pr_body_source == PrBodySource.TEMPLATE:
+            repo = Path(self.git_ctx.repo_root)
+            body = ""
+            for candidate in [
+                repo / ".github" / "PULL_REQUEST_TEMPLATE.md",
+                repo / "PULL_REQUEST_TEMPLATE.md",
+                repo / "docs" / "PULL_REQUEST_TEMPLATE.md",
+            ]:
+                if candidate.is_file():
+                    body = candidate.read_text().strip()
+                    break
+        else:
+            body = "\n".join(first_msg.split("\n")[1:]).strip()
+
+        return body, title
+
     def populate_update_info(
         self,
         update_pr_body_arg: bool,
         force_reviewers: bool = False,
+        pr_body_source: PrBodySource = PrBodySource.FIRST_COMMIT,
     ) -> None:
         """
         Populate information necessary to do PR creation / update in github.
@@ -1153,9 +1195,7 @@ class TopicStack:
             raise RuntimeError("Need to query before updating")
 
         for topic in self.topics.values():
-            commit_msg_lines = topic.original_commits[0].commit_msg.split("\n")
-            body = "\n".join(commit_msg_lines[1:]).strip()
-            title = commit_msg_lines[0]
+            body, title = self._get_pr_body_and_title(topic, pr_body_source)
             for branch, review in topic.reviews.items():
                 if review.status == PrStatus.NEW:
                     if not review.base_ref:

--- a/revup/upload.py
+++ b/revup/upload.py
@@ -70,7 +70,7 @@ async def main(
         return 0
 
     if not args.push_only:
-        topics.populate_update_info(args.update_pr_body, args.force_reviewers)
+        topics.populate_update_info(args.update_pr_body, args.force_reviewers, args.pr_body_source)
     if not args.skip_confirm and topics.num_reviews_changed() > 0:
         topics.print(not args.verbose)
         if git_ctx.sh.wait_for_confirmation():

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -3,7 +3,7 @@ import argparse
 import pytest
 from git_env import GitTestEnvironment, async_test
 
-from revup.topic_stack import TopicStack, format_remote_branch
+from revup.topic_stack import PrBodySource, TopicStack, format_remote_branch
 from revup.types import RevupConflictException, RevupUsageException
 
 
@@ -761,3 +761,79 @@ class TestUploadMultipleBranches:
                 assert review.base_ref == root_hash
                 content = await get_file_at_ref(env, review.new_commits[-1], "a.txt")
                 assert content == "hello"
+
+
+class TestPrBodySource:
+    @async_test
+    async def test_first_commit_uses_first_commit_body(self):
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("title\n\nfirst body\n\nTopic: alpha", {"a.txt": "a"})
+            await env.commit("second\n\nsecond body\n\nTopic: alpha", {"b.txt": "b"})
+
+            topics = await run_upload_pipeline(env)
+            topic = topics.topics["alpha"]
+            body, title = topics._get_pr_body_and_title(topic, PrBodySource.FIRST_COMMIT)
+
+            assert title == "title"
+            assert "first body" in body
+            assert "second body" not in body
+
+    @async_test
+    async def test_squashed_merges_all_commit_bodies(self):
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("title one\n\nbody one\n\nTopic: alpha", {"a.txt": "a"})
+            await env.commit("title two\n\nbody two\n\nTopic: alpha", {"b.txt": "b"})
+
+            topics = await run_upload_pipeline(env)
+            topic = topics.topics["alpha"]
+            body, title = topics._get_pr_body_and_title(topic, PrBodySource.SQUASHED)
+
+            assert "body one" in body
+            assert "body two" in body
+
+    @async_test
+    async def test_squashed_strips_tags(self):
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit(
+                "feat\n\nreal content\n\nTopic: alpha\nReviewer: alice", {"a.txt": "a"}
+            )
+
+            topics = await run_upload_pipeline(env)
+            topic = topics.topics["alpha"]
+            body, title = topics._get_pr_body_and_title(topic, PrBodySource.SQUASHED)
+
+            assert "alice" not in body
+            assert "Topic" not in body
+            assert "real content" in body
+
+    @async_test
+    async def test_template_reads_github_template(self):
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("feat\n\nTopic: alpha", {"a.txt": "a"})
+
+            # Create a PR template
+            await env.write_file(".github/PULL_REQUEST_TEMPLATE.md", "## Summary\n\n## Test Plan\n")
+
+            topics = await run_upload_pipeline(env)
+            topic = topics.topics["alpha"]
+            body, title = topics._get_pr_body_and_title(topic, PrBodySource.TEMPLATE)
+
+            assert "## Summary" in body
+            assert "## Test Plan" in body
+            assert title == "feat"
+
+    @async_test
+    async def test_template_returns_empty_when_no_template(self):
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("feat\n\nbody text\n\nTopic: alpha", {"a.txt": "a"})
+
+            topics = await run_upload_pipeline(env)
+            topic = topics.topics["alpha"]
+            body, title = topics._get_pr_body_and_title(topic, PrBodySource.TEMPLATE)
+
+            assert body == ""


### PR DESCRIPTION
Allows configuring how the pr body is created

- first commit (default today)
- squashed from the bodies of all commits
- from the github pr template file (not from commit text at all)

Fixes: #164
Fixes: #78