### PR TITLE
upload: Fix CODEOWNERS issues with orphaned changes

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -1022,6 +1022,50 @@ class TopicStack:
             ]
             await self.git_ctx.git(*fetch_args)
 
+    async def retarget_orphaned_prs(self) -> None:
+        """
+        Detect PRs whose previous target branch is no longer being pushed in this run.
+        Retarget them to the base branch as a safe intermediate before pushing.
+        This works around an issue where orphaning a change and rebasing will temporarily
+        cause github to see the entire upstream history in the PR diff, and mistakenly thrashes
+        a bunch of stuff like CODEOWNERS.
+        """
+        if not self.github_ep or not self.repo_info:
+            return
+
+        # Collect the set of branches we're pushing this run
+        pushing_branches: Set[str] = set()
+        for _, _, _, review in self.all_reviews_iter():
+            if review.push_status == PushStatus.PUSHED and review.status != PrStatus.MERGED:
+                pushing_branches.add(review.remote_head)
+
+        orphaned_updates: List[PrUpdate] = []
+        for _, _, base_branch, review in self.all_reviews_iter():
+            if not review.pr_info or review.status == PrStatus.MERGED:
+                continue
+            old_target = review.pr_info.baseRef
+            new_target = review.remote_base
+            if (
+                old_target != new_target
+                and old_target not in pushing_branches
+                and old_target != self.git_ctx.remove_branch_prefix(base_branch)
+            ):
+                base = self.git_ctx.remove_branch_prefix(base_branch)
+                logging.debug(
+                    f"Orphaned PR {review.remote_head}: old target {old_target} not being"
+                    f" pushed, retargeting to {base} before push"
+                )
+                update = PrUpdate()
+                update.id = review.pr_info.id
+                update.baseRef = base
+                orphaned_updates.append(update)
+                # Update cached state so update_prs() sees the new base and
+                # retargets to the final desired branch if different.
+                review.pr_info.baseRef = base
+
+        if orphaned_updates:
+            await github_utils.update_pull_requests(self.github_ep, orphaned_updates)
+
     async def push_git_refs(self, uploader: str, create_local_branches: bool) -> None:
         """
         Push all refs to their branch on the remote.

--- a/revup/upload.py
+++ b/revup/upload.py
@@ -95,6 +95,8 @@ async def main(
         if args.patchsets:
             # Patchsets require completed commit ids
             await topics.populate_patchsets()
+        if not args.push_only:
+            await topics.retarget_orphaned_prs()
         # Must push refs after creating them. Includes the virtual diff branch for patchsets.
         await topics.push_git_refs(git_ctx.author, args.create_local_branches)
 


### PR DESCRIPTION
When a relative change is removed (either dropped, or just the
relationship removed but that change is no longer being pushed due to
rebase) *and* the push contains a rebase of upstream changes, github
will briefly see a very large upstream diff since push and update
are not atomic. This causes it to freak out about CODEOWNERS and such

Detect orphaned changes like this by seeing if the previous target
branch is not actively being pushed. This is essentially the most
general way to handle it and should catch esoteric corner cases such
as moving a change between two different Relative-Branch:es.

If a change is orphaned, retarget its PR to the base branch right before
pushing. We can't target to its actual base because it might not exist
yet, all pushes for one run are done in the same call. We have to do an
update after push anyway, so in that update we'll set the true final
base.

Fixes: #244