### PR TITLE
upload: Add a --skip-first-empty-commit flag

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -9,7 +9,8 @@ revup upload - Modify or create code reviews.
 `[--rebase] [--relative-chain] [--skip-confirm] [--dry-run] [--push-only]`
 `[--status] [--no-update-pr-body] [--review-graph]`
 `[--trim-tags] [--create-local-branches] [--patchsets] [--auto-add-users=<o>]`
-`[--force-reviewers] [--pr-body-source=<src>] [--labels=<labels>] [<topics>]`
+`[--force-reviewers] [--pr-body-source=<src>] [--skip-empty-first-commit]`
+`[--labels=<labels>] [<topics>]`
 
 # DESCRIPTION
 
@@ -227,6 +228,11 @@ repo root, or `docs/`) and takes the title from the first commit.
 **--auto-add-users**
 : If "no", do nothing extra. If "r2a", add users from the Reviewers tag as assignees.
 If "a2r", add users from the Assignees tag as reviewers. If "both", do both of the previous.
+
+**--skip-empty-first-commit**
+: Exclude the first commit of a topic when creating branches if it is empty. This allows
+using an empty commit purely for PR title and body text without that commit appearing in
+the merged history.
 
 **--head**
 : The name or commit of the branch to be uploaded. If not specified, defaults to HEAD.

--- a/revup/git.py
+++ b/revup/git.py
@@ -263,6 +263,7 @@ class Git:
         self.fork_point.cache_clear()  # pylint: disable=no-member
         self.distance_to_fork_point.cache_clear()  # pylint: disable=no-member
         self.have_identical_trees.cache_clear()  # pylint: disable=no-member
+        self.to_tree.cache_clear()  # pylint: disable=no-member
         self.merge_tree.cache_clear()  # pylint: disable=no-member
 
     def get_scratch_dir(self) -> str:
@@ -376,6 +377,10 @@ class Git:
             raise RevupUsageException(f"{ref} is not a branch name!")
 
         return GitCommitHash(stdout)
+
+    @lru_cache(maxsize=None)
+    async def to_tree(self, ref: str) -> GitTreeHash:
+        return GitTreeHash(await self.git_stdout("rev-parse", ref + "^{tree}"))
 
     @lru_cache(maxsize=None)
     async def fork_point(self, ref: str, baseRef: str) -> GitCommitHash:

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -197,6 +197,7 @@ def build_parser() -> Tuple[RevupArgParser, List[RevupArgParser]]:
         choices=PrBodySource,
         default=PrBodySource.FIRST_COMMIT,
     )
+    upload_parser.add_argument("--skip-empty-first-commit", action="store_true")
     upload_parser.add_argument("--head", default="HEAD")
 
     restack_parser.add_argument("--topicless-last", "-t", action="store_true")

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -940,7 +940,7 @@ class TopicStack:
                     else:
                         break
 
-    async def create_commits(self, trim_tags: bool) -> None:
+    async def create_commits(self, trim_tags: bool, skip_empty_first_commit: bool = False) -> None:
         """
         Populate new_commits for all reviews by cherry-picking to the base ref if necessary.
         """
@@ -962,7 +962,13 @@ class TopicStack:
                 raise RuntimeError("Bug! review doesn't have a base ref")
 
             next_parent = review.base_ref
-            for commit in topic.original_commits:
+            for i, commit in enumerate(topic.original_commits):
+                if (
+                    skip_empty_first_commit
+                    and i == 0
+                    and commit.tree == await self.git_ctx.to_tree(commit.parents[0])
+                ):
+                    continue
                 if commit.parents[0] == next_parent and not trim_tags:
                     # If the intended parent is the same as the actual parent, skip the
                     # cherry-pick process (unless the commit msg needs to change).

--- a/revup/upload.py
+++ b/revup/upload.py
@@ -63,7 +63,7 @@ async def main(
 
     with get_console().status("Creating commits…"):
         # Need to know rebase information before creating commits
-        await topics.create_commits(args.trim_tags)
+        await topics.create_commits(args.trim_tags, args.skip_empty_first_commit)
 
     if args.dry_run:
         topics.print(not args.verbose)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -39,6 +39,7 @@ def make_upload_args(**kwargs):
         "relative_chain": False,
         "auto_topic": False,
         "head": "HEAD",
+        "skip_empty_first_commit": False,
         "verbose": False,
     }
     defaults.update(kwargs)
@@ -78,7 +79,7 @@ async def run_upload_pipeline(env, **kwargs):
         args.uploader if args.uploader else env.git_ctx.author,
         branch_format=args.branch_format,
     )
-    await topics.create_commits(args.trim_tags)
+    await topics.create_commits(args.trim_tags, args.skip_empty_first_commit)
     return topics
 
 
@@ -1250,3 +1251,48 @@ class TestRebaseDetection:
             await topics.mark_rebases(skip_rebase=True)
 
             assert review.is_pure_rebase
+
+
+class TestSkipEmptyFirstCommit:
+    @async_test
+    async def test_empty_first_commit_skipped(self):
+        """An empty first commit should be excluded from the cherry-picked branch."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            # Empty commit (no diff) used for PR title/body
+            await env.git_ctx.git("commit", "--allow-empty", "-m", "PR description\n\nTopic: feat")
+            # Real commit with changes
+            await env.commit("implement\n\nTopic: feat", {"a.txt": "content"})
+
+            topics = await run_upload_pipeline(env, skip_empty_first_commit=True)
+
+            review = topics.topics["feat"].reviews["origin/main"]
+            assert len(review.new_commits) == 1
+            content = await get_file_at_ref(env, review.new_commits[-1], "a.txt")
+            assert content == "content"
+
+    @async_test
+    async def test_empty_first_commit_kept_when_disabled(self):
+        """With the flag off, an empty first commit is included normally."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.git_ctx.git("commit", "--allow-empty", "-m", "PR description\n\nTopic: feat")
+            await env.commit("implement\n\nTopic: feat", {"a.txt": "content"})
+
+            topics = await run_upload_pipeline(env, skip_empty_first_commit=False)
+
+            review = topics.topics["feat"].reviews["origin/main"]
+            assert len(review.new_commits) == 2
+
+    @async_test
+    async def test_nonempty_first_commit_not_skipped(self):
+        """A first commit with actual changes should never be skipped."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("first\n\nTopic: feat", {"a.txt": "v1"})
+            await env.commit("second\n\nTopic: feat", {"a.txt": "v2"})
+
+            topics = await run_upload_pipeline(env, skip_empty_first_commit=True)
+
+            review = topics.topics["feat"].reviews["origin/main"]
+            assert len(review.new_commits) == 2


### PR DESCRIPTION
Allows using an empty commit for pr body / text without it appearing in history.