### PR TITLE
tests: Add test coverage output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,6 @@ man:
 	done
 
 test:
-	$(PYTHON) -m pytest tests/
+	$(PYTHON) -m pytest --cov=revup --cov-report=term-missing tests/
 
 .PHONY: all deps man install package format check_format check_types pylint lint clean

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ dev =
     build
     twine
     pytest
+    pytest-cov
     pytest-mock
 
 [options.packages.find]


### PR DESCRIPTION
Show per file test coverage when running "make test"