### PR TITLE
build: Switch formatter from black/isort to ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,17 +8,16 @@ all: deps lint man package install
 deps:
 	$(PYTHON) -m pip install .[dev]
 
-# Format using black
-BLACK_CMD=$(PYTHON) -m black --line-length 100 -t py38 --preview --exclude "build/.*|\.eggs/.*"
-ISORT_CMD=$(PYTHON) -m isort --profile black --py 38
+# Format using ruff
+RUFF_CMD=$(PYTHON) -m ruff
 format:
-	$(BLACK_CMD) .
-	$(ISORT_CMD) .
+	$(RUFF_CMD) format .
+	$(RUFF_CMD) check --select I --fix .
 
-# Check formatting using black
+# Check formatting using ruff
 check_format:
-	$(BLACK_CMD) --check --diff .
-	$(ISORT_CMD) --check --diff .
+	$(RUFF_CMD) format --check --diff .
+	$(RUFF_CMD) check --select I --diff .
 
 MYPY_COMMAND=$(PYTHON) -m mypy --show-error-codes
 check_types:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+line-length = 100
+target-version = "py38"
+extend-exclude = ["build", ".eggs"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["revup"]

--- a/revup/forge_utils.py
+++ b/revup/forge_utils.py
@@ -128,5 +128,5 @@ async def forge_connection(
             await forge.close()
     else:
         raise RevupUsageException(
-            f'Unrecognized forge URL "{args.forge_url}". ' "Currently only GitHub is supported."
+            f'Unrecognized forge URL "{args.forge_url}". Currently only GitHub is supported.'
         )

--- a/revup/git.py
+++ b/revup/git.py
@@ -465,10 +465,12 @@ class Git:
         if prune_old:
             fork_with_main = await self.fork_point(commit, f"{self.remote_name}/{self.main_branch}")
             # A branch that doesn't contain the fork with main must be too old
-            args.extend((
-                "--contains",
-                fork_with_main,
-            ))
+            args.extend(
+                (
+                    "--contains",
+                    fork_with_main,
+                )
+            )
 
         RE_REMOTE_REF = re.compile(r"^refs/remotes/(?P<branch>.*)$")
         ret: List[str] = []

--- a/revup/github/github.py
+++ b/revup/github/github.py
@@ -442,15 +442,17 @@ class Github(Forge):
                 if self.fork_info.owner == self.repo_info.owner
                 else f"{self.fork_info.owner}:{pr.headRef}"
             )
-            inputs.append({
-                "baseRefName": pr.baseRef,
-                "body": pr.body,
-                "clientMutationId": "revup",
-                "headRefName": headRef,
-                "repositoryId": repo_id,
-                "title": pr.title,
-                "draft": pr.is_draft,
-            })
+            inputs.append(
+                {
+                    "baseRefName": pr.baseRef,
+                    "body": pr.body,
+                    "clientMutationId": "revup",
+                    "headRefName": headRef,
+                    "repositoryId": repo_id,
+                    "title": pr.title,
+                    "draft": pr.is_draft,
+                }
+            )
         inputs_args = _get_args_dict(inputs, "pr")
         prs_out = _get_result_args(len(inputs), "pr_out")
 
@@ -506,52 +508,66 @@ class Github(Forge):
             inputs.append(update_dict)
 
             if pr.label_ids:
-                labels.append({
-                    "labelIds": list(pr.label_ids),
-                    "clientMutationId": "revup",
-                    "labelableId": pr.id,
-                })
+                labels.append(
+                    {
+                        "labelIds": list(pr.label_ids),
+                        "clientMutationId": "revup",
+                        "labelableId": pr.id,
+                    }
+                )
 
             if pr.reviewer_ids or pr.reviewer_team_ids:
-                reviewers.append({
-                    "userIds": list(pr.reviewer_ids),
-                    "teamIds": list(pr.reviewer_team_ids),
-                    "clientMutationId": "revup",
-                    "pullRequestId": pr.id,
-                    "union": True,
-                })
+                reviewers.append(
+                    {
+                        "userIds": list(pr.reviewer_ids),
+                        "teamIds": list(pr.reviewer_team_ids),
+                        "clientMutationId": "revup",
+                        "pullRequestId": pr.id,
+                        "union": True,
+                    }
+                )
             if pr.assignee_ids:
-                assignees.append({
-                    "assigneeIds": list(pr.assignee_ids),
-                    "clientMutationId": "revup",
-                    "assignableId": pr.id,
-                })
+                assignees.append(
+                    {
+                        "assigneeIds": list(pr.assignee_ids),
+                        "clientMutationId": "revup",
+                        "assignableId": pr.id,
+                    }
+                )
 
             if pr.is_draft is not None:
                 if pr.is_draft:
-                    convert_to_draft.append({
-                        "clientMutationId": "revup",
-                        "pullRequestId": pr.id,
-                    })
+                    convert_to_draft.append(
+                        {
+                            "clientMutationId": "revup",
+                            "pullRequestId": pr.id,
+                        }
+                    )
                 else:
-                    convert_from_draft.append({
-                        "clientMutationId": "revup",
-                        "pullRequestId": pr.id,
-                    })
+                    convert_from_draft.append(
+                        {
+                            "clientMutationId": "revup",
+                            "pullRequestId": pr.id,
+                        }
+                    )
 
             for c in pr.comments:
                 if c.id:
-                    edit_comments.append({
-                        "body": c.text,
-                        "clientMutationId": "revup",
-                        "id": c.id,
-                    })
+                    edit_comments.append(
+                        {
+                            "body": c.text,
+                            "clientMutationId": "revup",
+                            "id": c.id,
+                        }
+                    )
                 else:
-                    comments.append({
-                        "body": c.text,
-                        "clientMutationId": "revup",
-                        "subjectId": pr.id,
-                    })
+                    comments.append(
+                        {
+                            "body": c.text,
+                            "clientMutationId": "revup",
+                            "subjectId": pr.id,
+                        }
+                    )
 
         inputs_args = _get_args_dict(inputs, "pr")
         prs_out = _get_result_args(len(inputs), "pr_out")

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -816,10 +816,12 @@ class TopicStack:
                 # Check rebase by applying each local commit onto the remote parent
                 # and comparing the resulting tree to the remote tree.
                 is_rebase = len(review.remote_commits) == len(topic.original_commits) and all(
-                    await asyncio.gather(*(
-                        self.git_ctx.commits_are_equivalent(local, remote)
-                        for local, remote in zip(topic.original_commits, review.remote_commits)
-                    ))
+                    await asyncio.gather(
+                        *(
+                            self.git_ctx.commits_are_equivalent(local, remote)
+                            for local, remote in zip(topic.original_commits, review.remote_commits)
+                        )
+                    )
                 )
                 # This review is a "complete rebase" iff all commit diffs and metadata match
                 review.is_pure_rebase = is_rebase and all(

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,8 +57,7 @@ include_package_data=True
 
 [options.extras_require]
 dev =
-    black==24.1.1
-    isort
+    ruff==0.15.16
     pylint==3.2.7
     mypy==1.13.0
     build

--- a/tests/fake_forge.py
+++ b/tests/fake_forge.py
@@ -173,9 +173,9 @@ class FakeForge(Forge):
             # baseRef must differ from current if specified
             if update.baseRef is not None:
                 assert update.baseRef, "baseRef cannot be empty string"
-                assert (
-                    update.baseRef != target_pr.headRef
-                ), f"cannot set baseRef to headRef ({update.baseRef})"
+                assert update.baseRef != target_pr.headRef, (
+                    f"cannot set baseRef to headRef ({update.baseRef})"
+                )
 
             # title cannot be empty if specified
             if update.title is not None:


### PR DESCRIPTION
ruff format + ruff check --select I replace the black + isort pair.
Drops two dev deps for one and runs noticeably faster. Source files
themselves are unchanged in this commit; a follow-up pass will
normalize the few cases where ruff and black disagree.