### PR TITLE
git: Replace a few porcelain commands with plumbing commands

### DIFF
--- a/revup/amend.py
+++ b/revup/amend.py
@@ -229,10 +229,13 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
     """
 
     async def get_has_unstaged() -> bool:
+        # Not converted to plumbing (diff-files/diff-index). This compares the
+        # worktree, where diff-index returns 1 on a stale mtime even with no content
+        # change, so it would report spurious unstaged changes.
         return args.all and await git_ctx.git_return_code("diff", "--no-renames", "--quiet") != 0
 
     has_staged, has_unstaged = await asyncio.gather(
-        git_ctx.git_return_code("diff", "--cached", "--no-renames", "--quiet"),
+        git_ctx.git_return_code("diff-index", "--cached", "--no-renames", "--quiet", "HEAD"),
         get_has_unstaged(),
     )
 
@@ -266,7 +269,7 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
 
     if args.last_touched:
         staged_files_output = await git_ctx.git_stdout(
-            "diff", "--cached", "--name-only", "--no-renames"
+            "diff-index", "--cached", "-r", "--name-only", "--no-renames", "HEAD"
         )
         if not staged_files_output:
             return 0
@@ -338,7 +341,7 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
             await get_topic_summary(topics) if args.parse_topics else "",
             stack[0].commit_msg,
             (
-                await git_ctx.git_stdout("--no-pager", "diff", "--cached", "--stat", "--no-color")
+                await git_ctx.git_stdout("diff-index", "--cached", "-r", "-M", "HEAD", "--stat")
                 if has_diff
                 else ""
             ),
@@ -346,7 +349,7 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
                 ""
                 if args.insert
                 else await git_ctx.git_stdout(
-                    "--no-pager", "diff", commit + "~", commit, "--stat", "--no-color"
+                    "diff-tree", "-r", "-M", commit + "~", commit, "--stat"
                 )
             ),
         )

--- a/revup/git.py
+++ b/revup/git.py
@@ -525,9 +525,13 @@ class Git:
         ret = candidates[0]
         if len(candidates) == 1:
             return ret
-        current_branch = (await self.git("branch", "--show-current"))[1]
+        # symbolic-ref errors (rc != 0) on a detached HEAD; treat that as no branch.
+        ret_code, branch_out = await self.git(
+            "symbolic-ref", "-q", "--short", "HEAD", raiseonerror=False
+        )
+        current_branch = branch_out if ret_code == 0 else None
         for c in candidates:
-            if c == f"{self.remote_name}/{current_branch}":
+            if current_branch is not None and c == f"{self.remote_name}/{current_branch}":
                 ret = c
                 break
             elif c == f"{self.remote_name}/{self.main_branch}":
@@ -640,7 +644,9 @@ class Git:
         Return the summary of the diff (files and lines changed)
         """
         return (
-            await self.git_stdout("diff", "--shortstat", parent, commit, no_config=True)
+            await self.git_stdout(
+                "diff-tree", "-r", "-M", "--shortstat", parent, commit, no_config=True
+            )
         ).rstrip()
 
     async def merge_tree_commit(
@@ -689,7 +695,7 @@ class Git:
         """
         groups: List[List[int]] = []
         conflict_depth = 0
-        lines = (await self.git_stdout("show", f"{tree}:{path}")).split("\n")
+        lines = (await self.git_stdout("cat-file", "-p", f"{tree}:{path}")).split("\n")
         for lineno, line in enumerate(lines):
             if line.startswith("<" * 7):
                 if conflict_depth == 0:


### PR DESCRIPTION
- diff --cached -> diff-index --cached (index vs tree, immune to the
  stale-mtime quirk)
- diff <commit>~ <commit> -> diff-tree
- stat/shortstat conversions add -M since porcelain detects renames by
  default; --no-renames cases don't.
- -r is added so subdirectories are recursed.

The worktree comparison in get_has_unstaged is intentionally left as
porcelain: diff-index returns 1 on a refreshed mtime with no content
change, which would report spurious unstaged changes.

- branch --show-current -> symbolic-ref -q --short HEAD. The -q with
  raiseonerror=False preserves the porcelain behavior of returning empty
  on a detached HEAD instead of erroring.
- show <tree>:<path> -> cat-file -p, the plumbing equivalent for reading
  a blob, used when dumping conflict markers.