### PR TITLE
lint: Enable broader ruff checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ deps:
 RUFF_CMD=$(PYTHON) -m ruff
 format:
 	$(RUFF_CMD) format .
-	$(RUFF_CMD) check --select I --fix .
+	$(RUFF_CMD) check --fix .
 
 # Check formatting using ruff
 check_format:
 	$(RUFF_CMD) format --check --diff .
-	$(RUFF_CMD) check --select I --diff .
+	$(RUFF_CMD) check --diff .
 
 MYPY_COMMAND=$(PYTHON) -m mypy --show-error-codes
 check_types:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,9 @@ line-length = 100
 target-version = "py38"
 extend-exclude = ["build", ".eggs"]
 
+[tool.ruff.lint]
+# Keep ruff's default rules (E, F) and also run import sorting (I).
+extend-select = ["I"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["revup"]

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -1144,8 +1144,8 @@ class TopicStack:
                 stdout=subprocess.STDOUT,
                 stderr=subprocess.STDOUT,
                 # Hide the remote output that says "Create a pull request for '' on GitHub"
-                output_transform=lambda l: (
-                    b"" if (l.startswith(b"remote: ") and self.git_ctx.sh.quiet) else l
+                output_transform=lambda line: (
+                    b"" if (line.startswith(b"remote: ") and self.git_ctx.sh.quiet) else line
                 ),
             )
 

--- a/tests/test_restack.py
+++ b/tests/test_restack.py
@@ -1,4 +1,3 @@
-import pytest
 from git_env import GitTestEnvironment, async_test
 
 from revup.restack import restack

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,5 @@
 import asyncio
 import builtins
-import dataclasses
 import io
 import sys
 from unittest import mock

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1343,7 +1343,7 @@ async def full_upload_pipeline(env, forge, push=False, stop_after=None, **kwargs
     Run the full upload pipeline via upload.run() generator.
     If stop_after is set to an UploadPhase, stops after that phase yields.
     """
-    from revup.upload import UploadPhase, run
+    from revup.upload import run
 
     env.git_ctx.clear_cache()
     args = make_forge_upload_args(**kwargs)


### PR DESCRIPTION
Previously we were only using ruff -I for import sorting.
This also add checking for style errors and fixes the ones
currently in the repo.