### PR TITLE
upload: Propagate PUSHED status down relative review graph

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -915,29 +915,47 @@ class TopicStack:
                     review.status = PrStatus.NEW
 
             if review.push_status == PushStatus.PUSHED:
-                # If this change must be pushed, then all changes it depends on cannot be
-                # skipped due to rebase (although can be due to nochange), otherwise the
-                # forge will show the wrong commit diff between the two reviews
-                cur_topic = topic.relative_topic
-                while cur_topic is not None:
-                    cur_review = cur_topic.reviews[base_branch]
-                    if cur_review.push_status == PushStatus.REBASE:
-                        cur_review.push_status = PushStatus.PUSHED
-                        if cur_review.status == PrStatus.MERGED:
-                            # User has changed the base of an already merged commit, but hasn't
-                            # moved forward enough such that the commit would be dropped. There
-                            # isn't any way for us to handle this that wouldn't potentially
-                            # generate a conflict or show the incorrect commit diff. We settle
-                            # with showing the wrong diff and warning the user.
-                            # This should be relatively uncommon
-                            logging.warning(
-                                f"Attempted to rebase an already merged PR {cur_topic.name}"
-                            )
-                            logging.warning("'git pull' and upload again to fix this.")
+                self._propagate_pushed_through_graph(topic, base_branch)
 
-                        cur_topic = cur_topic.relative_topic
-                    else:
-                        break
+    def _promote_rebase_to_pushed(self, review: Review, topic_name: str) -> None:
+        if review.push_status != PushStatus.REBASE:
+            return
+        review.push_status = PushStatus.PUSHED
+        if review.status == PrStatus.MERGED:
+            logging.warning(f"Attempted to rebase an already merged PR {topic_name}")
+            logging.warning("'git pull' and upload again to fix this.")
+
+    def _propagate_pushed_through_graph(self, topic: Topic, base_branch: str) -> None:
+        """
+        If this change must be pushed, dependent topics cannot stay REBASE-only skips.
+        Walk ancestors via relative_topic and descendants via review.children (#163).
+        """
+        review = topic.reviews[base_branch]
+        if review.push_status != PushStatus.PUSHED:
+            return
+
+        stack: List[Review] = [review]
+        cur_topic = topic.relative_topic
+        while cur_topic is not None:
+            cur_review = cur_topic.reviews[base_branch]
+            self._promote_rebase_to_pushed(cur_review, cur_topic.name)
+            stack.append(cur_review)
+            cur_topic = cur_topic.relative_topic
+
+        visited: Set[int] = set()
+        while stack:
+            cur_review = stack.pop()
+            review_id = id(cur_review)
+            if review_id in visited:
+                continue
+            visited.add(review_id)
+            for child_review in cur_review.children:
+                if child_review.push_status == PushStatus.REBASE:
+                    child_review.push_status = PushStatus.PUSHED
+                    if child_review.status == PrStatus.MERGED:
+                        logging.warning("Attempted to rebase an already merged PR")
+                        logging.warning("'git pull' and upload again to fix this.")
+                stack.append(child_review)
 
     async def create_commits(self, trim_tags: bool, skip_empty_first_commit: bool = False) -> None:
         """

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -15,6 +15,8 @@ from revup.topic_stack import (
     format_remote_branch,
 )
 from revup.types import RevupConflictException, RevupUsageException
+from test_amend import make_amend_args
+from revup import amend as revup_amend
 
 
 def make_upload_args(**kwargs):
@@ -1146,6 +1148,76 @@ class TestRebaseDetection:
             assert c_review.push_status == PushStatus.PUSHED
             # Parent would normally be REBASE, but child forces it to PUSHED
             assert p_review.push_status == PushStatus.PUSHED
+
+    @async_test
+    async def test_rebase_pushed_propagates_to_sibling_children(self):
+        """When one child forces a push, sibling children of the parent are also pushed (#163)."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            root = await env.get_commit_hash()
+            await env.commit("parent\n\nTopic: parent", {"p.txt": "p"})
+            await env.commit("child_a\n\nTopic: child_a\nRelative: parent", {"a.txt": "a"})
+            await env.commit("child_b\n\nTopic: child_b\nRelative: parent", {"b.txt": "b"})
+
+            first = await run_upload_pipeline(env)
+            parent_review = first.topics["parent"].reviews["origin/main"]
+            child_a_review = first.topics["child_a"].reviews["origin/main"]
+            child_b_review = first.topics["child_b"].reviews["origin/main"]
+            parent_remote_head = parent_review.new_commits[-1]
+            parent_remote_base = parent_review.base_ref
+            child_a_remote_head = child_a_review.new_commits[-1]
+            child_a_remote_base = child_a_review.base_ref
+            child_b_remote_head = child_b_review.new_commits[-1]
+            child_b_remote_base = child_b_review.base_ref
+
+            await env.git_ctx.git("checkout", root)
+            await env.commit("upstream", {"u.txt": "u"})
+            new_main = await env.get_commit_hash()
+            await env.git_ctx.git("branch", "origin/main", new_main, "-f")
+            await env.git_ctx.git("checkout", "main")
+            await env.git_ctx.git("rebase", "origin/main")
+            await env.stage_file("a.txt", "a2")
+            args = make_amend_args(ref_or_topic="HEAD~1", edit=False)
+            await revup_amend.main(args, env.git_ctx)
+
+            topics = await run_upload_pipeline(env)
+            p_review = topics.topics["parent"].reviews["origin/main"]
+            a_review = topics.topics["child_a"].reviews["origin/main"]
+            b_review = topics.topics["child_b"].reviews["origin/main"]
+
+            p_review.pr_info = PrInfo(
+                baseRef="main",
+                headRef=p_review.remote_head,
+                baseRefOid=parent_remote_base,
+                headRefOid=parent_remote_head,
+                body="",
+                title="",
+                state="OPEN",
+            )
+            a_review.pr_info = PrInfo(
+                baseRef=p_review.remote_head,
+                headRef=a_review.remote_head,
+                baseRefOid=child_a_remote_base,
+                headRefOid=child_a_remote_head,
+                body="",
+                title="",
+                state="OPEN",
+            )
+            b_review.pr_info = PrInfo(
+                baseRef=p_review.remote_head,
+                headRef=b_review.remote_head,
+                baseRefOid=child_b_remote_base,
+                headRefOid=child_b_remote_head,
+                body="",
+                title="",
+                state="OPEN",
+            )
+
+            await topics.mark_rebases(skip_rebase=True)
+
+            assert a_review.push_status == PushStatus.PUSHED
+            assert p_review.push_status == PushStatus.PUSHED
+            assert b_review.push_status == PushStatus.PUSHED
 
     @async_test
     async def test_multi_commit_topic_partial_change_is_not_rebase(self):


### PR DESCRIPTION
## Summary
Fixes #163.

When rebase detection marks a topic as `PUSHED`, also promote dependent topics in the relative graph from `REBASE` to `PUSHED` by walking both ancestors (`relative_topic`) and descendants (`review.children`).

## Problem
After rebasing a stack and modifying a leaf topic, only one branch of the graph was promoted. Sibling children of a shared parent could remain `REBASE`, producing stale forge diffs.

## Verification
```
python3 -m pip install -e '.[dev]'
python3 -m pytest tests/test_upload.py::TestRebaseDetection::test_rebase_pushed_propagates_to_sibling_children -q
```