### PR TITLE
upload: Include relative dependencies when topics are specified

### DIFF
--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -500,11 +500,30 @@ class TopicStack:
         Populate reviews for already-parsed topics. Verify base branch and relative topic info to
         ensure it is valid.
         """
+        effective_limit: Optional[Set[str]] = None
+        if limit_topics:
+            effective_limit = set(limit_topics)
+            for name in limit_topics:
+                if name not in self.topics:
+                    continue
+                to_visit = [name]
+                while to_visit:
+                    cur_name = to_visit.pop()
+                    topic = self.topics.get(cur_name)
+                    if topic is None or not topic.tags[TAG_RELATIVE]:
+                        continue
+                    relative_name = min(topic.tags[TAG_RELATIVE])
+                    if relative_name not in self.topics:
+                        continue
+                    if relative_name not in effective_limit:
+                        effective_limit.add(relative_name)
+                        to_visit.append(relative_name)
+
         last_topic = None
         # Copy topics before iterating so it's safe to delete from the original dict
         for name, topic in list(self.topics.items()):
-            if limit_topics:
-                if name not in limit_topics:
+            if effective_limit is not None:
+                if name not in effective_limit:
                     # If an explicit list was specified, don't upload other topics
                     del self.topics[name]
                     continue

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -186,6 +186,21 @@ class TestUploadLimitTopics:
             review = topics.topics["alpha"].reviews["origin/main"]
             assert len(review.new_commits) == 1
 
+    @async_test
+    async def test_limit_topics_pulls_in_relative_dependencies(self):
+        """Uploading an explicit topic includes its relative dependency chain (#265)."""
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("base\n\nTopic: base", {"a.txt": "a"})
+            await env.commit("child\n\nTopic: child\nRelative: base", {"b.txt": "b"})
+            await env.commit("other\n\nTopic: other", {"c.txt": "c"})
+
+            topics = await run_upload_pipeline(env, topics=["child"])
+
+            assert "base" in topics.topics
+            assert "child" in topics.topics
+            assert "other" not in topics.topics
+
 
 class TestUploadRelativeTopics:
     @async_test


### PR DESCRIPTION
## Summary
Fixes #265.

`revup upload child` now also uploads `child`'s relative dependency chain (e.g. `base`) instead of ignoring dependencies and risking conflicts.

## Verification
```
python3 -m pip install -e '.[dev]'
python3 -m pytest tests/test_upload.py::TestUploadLimitTopics::test_limit_topics_pulls_in_relative_dependencies -q
```