### PR TITLE
amend: Add --run-hooks to invoke post-rewrite hook

### DIFF
--- a/revup/amend.py
+++ b/revup/amend.py
@@ -293,7 +293,10 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
         if not new_commit:
             return 0
 
+        old_head = GitCommitHash(await git_ctx.git_stdout("rev-parse", "HEAD"))
         await git_ctx.soft_reset(new_commit, {"GIT_REFLOG_ACTION": "revup amend --last-touched"})
+        if args.run_hooks and old_head != new_commit:
+            await git_ctx.run_post_rewrite_hook("amend", old_head, new_commit)
         return 0
 
     if args.ref_or_topic:
@@ -413,5 +416,8 @@ async def main(args: argparse.Namespace, git_ctx: git.Git) -> int:
     git_env = {
         "GIT_REFLOG_ACTION": reflog_action_str,
     }
+    old_head = GitCommitHash(await git_ctx.git_stdout("rev-parse", "HEAD"))
     await git_ctx.soft_reset(new_commit, git_env)
+    if args.run_hooks and old_head != new_commit:
+        await git_ctx.run_post_rewrite_hook("amend", old_head, new_commit)
     return 0

--- a/revup/git.py
+++ b/revup/git.py
@@ -586,6 +586,28 @@ class Git:
         ret = await self.git_stdout(*commit_tree_args, env=git_env)
         return GitCommitHash(ret)
 
+    async def run_post_rewrite_hook(
+        self, command: str, old_commit: GitCommitHash, new_commit: GitCommitHash
+    ) -> int:
+        """
+        Invoke the post-rewrite hook the same way git would after amend/rebase (#42).
+        """
+        stdin_path = f"{self.get_scratch_dir()}/post-rewrite-in"
+        os.makedirs(self.get_scratch_dir(), exist_ok=True)
+        with open(stdin_path, mode="w", encoding="utf-8") as hook_input:
+            hook_input.write(f"{old_commit} {new_commit}\n")
+        ret, _ = await self.git(
+            "hook",
+            "run",
+            "--ignore-missing",
+            f"--to-stdin={stdin_path}",
+            "post-rewrite",
+            "--",
+            command,
+            raiseonerror=False,
+        )
+        return ret
+
     @lru_cache(maxsize=None)
     async def merge_tree(
         self,

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -229,6 +229,11 @@ def build_parser() -> Tuple[RevupArgParser, List[RevupArgParser]]:
 
     amend_parser.add_argument("--parse-topics", default=True, action="store_true")
     amend_parser.add_argument("--parse-refs", default=True, action="store_true")
+    amend_parser.add_argument(
+        "--run-hooks",
+        action="store_true",
+        help="Run git post-rewrite hook after rewriting history",
+    )
 
     cherry_pick_parser.add_argument("--help", "-h", action=HelpAction, nargs=0)
     cherry_pick_parser.add_argument("branch_or_pr_url", nargs=1)

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -1,4 +1,5 @@
 import argparse
+from pathlib import Path
 
 import pytest
 from git_env import (
@@ -25,6 +26,7 @@ def make_amend_args(**kwargs):
         "relative_branch": None,
         "parse_topics": False,
         "parse_refs": True,
+        "run_hooks": False,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -536,6 +538,28 @@ class TestAmendConflict:
 
             with pytest.raises(RevupConflictException):
                 await amend.main(args, env.git_ctx)
+
+
+class TestAmendRunHooks:
+    @async_test
+    async def test_run_hooks_invokes_post_rewrite(self):
+        async with GitTestEnvironment() as env:
+            await env.commit("root", {"root.txt": "r"})
+            await env.commit("first", {"a.txt": "a"})
+
+            hook_dir = Path(env.git_ctx.git_dir) / "hooks"
+            hook_dir.mkdir(exist_ok=True)
+            marker = env.tmp_dir / "hook_ran.txt"
+            hook = hook_dir / "post-rewrite"
+            hook.write_text(f'#!/bin/sh\necho "$1" > "{marker}"\n')
+            hook.chmod(0o755)
+
+            await env.stage_file("a.txt", "modified")
+            args = make_amend_args(edit=False, run_hooks=True)
+            ret = await amend.main(args, env.git_ctx)
+
+            assert ret == 0
+            assert marker.read_text().strip() == "amend"
 
 
 class TestAmendMultipleFiles:


### PR DESCRIPTION
## Summary
Fixes #42.

Adds `revup amend --run-hooks` to invoke git's `post-rewrite` hook after history is rewritten, with the same stdin format git uses for native amend.

## Verification
```
python3 -m pip install -e '.[dev]'
python3 -m pytest tests/test_amend.py::TestAmendRunHooks -q
```