### PR TITLE
git: Don't crash on a whitespace only commit msg

### DIFF
--- a/revup/git.py
+++ b/revup/git.py
@@ -53,7 +53,6 @@ def parse_commit_header(raw_header: str) -> CommitHeader:
         return m.group(group)
 
     tree = GitTreeHash(_search_group(raw_header, RE_RAW_TREE, "tree"))
-    title = _search_group(raw_header, RE_RAW_COMMIT_MSG_LINE, "line")
     commit_id = GitCommitHash(_search_group(raw_header, RE_RAW_COMMIT_ID, "commit"))
     parents = [GitCommitHash(m.group("commit")) for m in RE_RAW_PARENT.finditer(raw_header)]
     author_name = _search_group(raw_header, RE_RAW_AUTHOR, "name")
@@ -62,7 +61,11 @@ def parse_commit_header(raw_header: str) -> CommitHeader:
     committer_name = _search_group(raw_header, RE_RAW_COMMITTER, "name")
     committer_email = _search_group(raw_header, RE_RAW_COMMITTER, "email")
     committer_date = _search_group(raw_header, RE_RAW_COMMITTER, "date")
-    commit_msg = "\n".join(m.group("line") for m in RE_RAW_COMMIT_MSG_LINE.finditer(raw_header))
+    # A commit may have an empty message (no indented lines), so derive the title
+    # and message from whatever lines exist rather than asserting one is present.
+    msg_lines = [m.group("line") for m in RE_RAW_COMMIT_MSG_LINE.finditer(raw_header)]
+    title = msg_lines[0] if msg_lines else ""
+    commit_msg = "\n".join(msg_lines)
     return CommitHeader(
         tree,
         parents,

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -653,6 +653,24 @@ class TestUploadTopicValidation:
                 await run_upload_pipeline(env)
 
 
+class TestUploadEmptyMessageCommit:
+    @async_test
+    async def test_empty_message_commit_in_range(self):
+        # A commit with an empty message has no indented header lines; parsing it
+        # must not crash.
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.git_ctx.git("commit", "--allow-empty", "--allow-empty-message", "-m", "")
+            await env.commit("feat\n\nTopic: alpha", {"a.txt": "a"})
+
+            topics = await run_upload_pipeline(env)
+
+            assert "alpha" in topics.topics
+            review = topics.topics["alpha"].reviews["origin/main"]
+            content = await get_file_at_ref(env, review.new_commits[-1], "a.txt")
+            assert content == "a"
+
+
 class TestUploadCherryPickConflicts:
     @async_test
     async def test_same_file_different_topics_conflicts(self):


### PR DESCRIPTION
Currently we expect at least one nonws line of text per commit
message to act as the title. That may not be the case (git allows
empty commit messages). We do not want to crash if one of these
appears in the stack.