### PR TITLE
shell: Don't crash when decoding invalid output

### DIFF
--- a/revup/shell.py
+++ b/revup/shell.py
@@ -298,7 +298,10 @@ class Shell:
             raise RuntimeError("{} failed with exit code {}".format(" ".join(args), returncode))
 
         if stdout == subprocess.PIPE:
-            return (returncode, out.decode())  # do a strict decode for actual return
+            # Decode leniently: git output is usually UTF-8 but can contain
+            # arbitrary bytes. A strict decode would crash; replace keeps output
+            # displayable.
+            return (returncode, out.decode(errors="replace"))
         else:
             return (returncode, "")
 

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -537,6 +537,26 @@ class TestAmendConflict:
             with pytest.raises(RevupConflictException):
                 await amend.main(args, env.git_ctx)
 
+    @async_test
+    async def test_conflict_in_non_utf8_file_raises_cleanly(self):
+        # Dumping a conflict reads the conflicted file's content, which may not be
+        # valid UTF-8. This must raise RevupConflictException, not UnicodeDecodeError.
+        async with GitTestEnvironment() as env:
+            await env.commit("root", {"root.txt": "r"})
+            (env.tmp_dir / "bin.dat").write_bytes(b"\xff\xfe line1\nline2\nline3\n")
+            await env.git_ctx.git("add", "bin.dat")
+            await env.commit("first")
+            (env.tmp_dir / "bin.dat").write_bytes(b"\xff\xfe line1\nsecond\nline3\n")
+            await env.git_ctx.git("add", "bin.dat")
+            await env.commit("second")
+
+            (env.tmp_dir / "bin.dat").write_bytes(b"\xff\xfe line1\nconflict\nline3\n")
+            await env.git_ctx.git("add", "bin.dat")
+            args = make_amend_args(ref_or_topic="HEAD~1", edit=False)
+
+            with pytest.raises(RevupConflictException):
+                await amend.main(args, env.git_ctx)
+
 
 class TestAmendMultipleFiles:
     @async_test


### PR DESCRIPTION
git output can include invalid bytes, so we want to
leniently smooth the output instead of crashing.

This can happen on the conflict dump path if a file
contains invalid bytes.