### PR TITLE
config: Use interpolation=None

### DIFF
--- a/revup/config.py
+++ b/revup/config.py
@@ -126,7 +126,9 @@ class Config:
         repo_config_path: str = "",
         git_dir_config_path: str = "",
     ):
-        self.config = configparser.ConfigParser()
+        # interpolation=None: config values are literal and may contain '%'
+        # (labels, URLs, aliases); the default interpolation would crash on it.
+        self.config = configparser.ConfigParser(interpolation=None)
         self.config_path = config_path
         self.repo_config_path = repo_config_path
         self.git_dir_config_path = git_dir_config_path
@@ -138,7 +140,7 @@ class Config:
         for path in (self.config_path, self.repo_config_path, self.git_dir_config_path):
             if not path:
                 continue
-            file_conf = configparser.ConfigParser()
+            file_conf = configparser.ConfigParser(interpolation=None)
             if file_conf.read(path):
                 self.file_configs.append((path, file_conf))
             self.config.read(path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,6 +53,20 @@ class TestConfigSetAndRead:
             conf2.read()
             assert conf2.config.get("revup", "forge_url") == "github.enterprise.com"
 
+    def test_value_with_percent_sign(self):
+        # A '%' in a value must not trigger configparser interpolation on write or read.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "config")
+            conf = Config(path)
+            conf.read()
+
+            conf.set_value("upload", "labels", "rel-50%-done")
+            conf.write()
+
+            conf2 = Config(path)
+            conf2.read()
+            assert conf2.config.get("upload", "labels") == "rel-50%-done"
+
     def test_set_value_idempotent(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = os.path.join(tmp, "config")


### PR DESCRIPTION
configparser includes an interpolation feature where keys can
specify replacement with other keys. This is not necessary for us
and breaks keys with literal %, so turn it off.