### PR TITLE
build: Keep .coverage file out of repo root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,7 @@ extend-select = ["I"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["revup"]
+
+[tool.coverage.run]
+# Keep the coverage data file out of the repo root.
+data_file = "build/.coverage"


### PR DESCRIPTION
Running make test drops a file in repo root. Move that to
build/.