### PR TITLE
build: Move manpage logic into a shell script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,18 +35,8 @@ clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf .mypy_cache
 
-REVUP_VERSION:=$(shell $(PYTHON) revup/__init__.py)
+REVUP_VERSION:=$(shell $(PYTHON) revup/version.py)
 REVUP_DATE ?= Apr 21, 2021
-define REVUP_HEADER
----
-title: TITLE
-section: 1
-header: Revup Manual
-footer: revup VERSION
-date: DATE
----
-endef
-export REVUP_HEADER
 
 REVUP_VERSION_HASH?=${shell git rev-parse --short v$(REVUP_VERSION) || echo main}
 
@@ -66,13 +56,11 @@ upload:
 	$(PYTHON) -m twine upload build/revup-$(REVUP_VERSION).tar.gz
 
 man:
-	mkdir -p revup/man1 ; \
-	cd docs ; \
-	for file in *.md ; do \
-		CMD_NAME=`echo $${file} | awk -F'[.]' '{print $$1}'` ; \
-		echo "$${REVUP_HEADER}" | m4 -DTITLE=$${CMD_NAME} -DVERSION=$(REVUP_VERSION) -DDATE="$(REVUP_DATE)" - | \
-		cat - $${file} | pandoc -f markdown-smart -s -t man > ../revup/man1/$${CMD_NAME}.1 || exit 1 ; \
-		gzip -n -f -k ../revup/man1/$${CMD_NAME}.1 || exit 1 ; \
+	mkdir -p revup/man1
+	@for src in docs/*.md ; do \
+		name=$$(basename $${src} .md) ; \
+		scripts/build_manpage.sh "$${name}" "$(REVUP_VERSION)" "$(REVUP_DATE)" \
+			"$${src}" "revup/man1/$${name}.1.gz" || exit 1 ; \
 	done
 
 test:

--- a/revup/__init__.py
+++ b/revup/__init__.py
@@ -1,5 +1,0 @@
-__version__ = "0.4.0"
-
-if __name__ == "__main__":
-    # So that Makefile can get the version without having to parse python
-    print(__version__)

--- a/revup/revup.py
+++ b/revup/revup.py
@@ -8,7 +8,6 @@ import subprocess
 import sys
 from typing import Any, List, Tuple
 
-import revup
 from revup import config, git, logs, shell
 from revup.completion import (
     ShellType,
@@ -21,6 +20,7 @@ from revup.config import RevupArgParser
 from revup.forge_utils import parse_forge_info
 from revup.topic_stack import PrBodySource
 from revup.types import RevupUsageException
+from revup.version import REVUP_VERSION
 
 REVUP_CONFIG_ENV_VAR = "REVUP_CONFIG_PATH"
 CONFIG_FILE_NAME = ".revupconfig"
@@ -47,9 +47,7 @@ class HelpAction(argparse.Action):
 def make_toplevel_parser() -> RevupArgParser:
     revup_parser = RevupArgParser(add_help=False, prog="revup")
     revup_parser.add_argument("--help", "-h", action=HelpAction, nargs=0)
-    revup_parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {revup.__version__}"
-    )
+    revup_parser.add_argument("--version", action="version", version=f"%(prog)s {REVUP_VERSION}")
     revup_parser.add_argument("--proxy")
     revup_parser.add_argument("--forge-oauth", "--github-oauth")
     revup_parser.add_argument("--forge-url", "--github-url", default="github.com")

--- a/revup/version.py
+++ b/revup/version.py
@@ -1,0 +1,5 @@
+REVUP_VERSION = "0.4.0"
+
+if __name__ == "__main__":
+    # Lets Makefile read the version without parsing a Python file.
+    print(REVUP_VERSION)

--- a/scripts/build_manpage.sh
+++ b/scripts/build_manpage.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Build a gzipped man page from a markdown source.
+#
+# Usage: build_manpage.sh <name> <version> <date> <input.md> <output.1.gz>
+#
+# Composes a pandoc-style YAML header with m4, prepends it to the markdown,
+# pipes through pandoc, then gzip -n for reproducibility. Honors $M4 and
+# $PANDOC env vars so Bazel can supply hermetic toolchains; falls back to PATH.
+set -euo pipefail
+
+NAME=$1
+VERSION=$2
+DATE=$3
+INPUT=$4
+OUTPUT=$5
+
+: "${M4:=m4}"
+: "${PANDOC:=pandoc}"
+
+HEADER=$("$M4" \
+    -DTITLE="$NAME" \
+    -DVERSION="$VERSION" \
+    -DDATE="$DATE" \
+    <<'EOF'
+---
+title: TITLE
+section: 1
+header: Revup Manual
+footer: revup VERSION
+date: DATE
+---
+EOF
+)
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+printf '%s\n' "$HEADER" | cat - "$INPUT" \
+    | "$PANDOC" -f markdown-smart -s -t man > "$TMP/page.1"
+gzip -n -c "$TMP/page.1" > "$OUTPUT"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = revup
-version = attr: revup.__version__
+version = attr: revup.version.REVUP_VERSION
 author = Jerry Zhang
 author_email = jerry@skydio.com
 description = Revolutionary github tools. Effortlessly create multiple branches and pull requests.


### PR DESCRIPTION
This makes it easier to reuse across potential build systems.

Also move version into version.py so that it doesn't intercept init.py.