### PR TITLE
python: Remove dependency on requests and charset_normalizer

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,12 +44,10 @@ install_requires =
     argcomplete
     async_lru
     attrs
-    requests
     rich
     multidict
     yarl
     async_timeout
-    charset_normalizer
     aiosignal
 setup_requires = 
     setuptools


### PR DESCRIPTION
Both of these are completely unused, even transitively