### PR TITLE
docs: Update token requirements to include read:org

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ Creating test PRs can be spammy so don't do the tutorial on other people's repos
 git clone https://github.com/<your-name>/revup.git && cd revup
 ```
 
-On first run, you will need to configure github credentials. Create a [GitHub Personal Access Token](https://github.com/settings/tokens/new?scopes=repo)
-with "repo" scope. Revup needs this in order to create and modify pull requests. Then run
+On first run, you will need to configure github credentials. Create a [GitHub Personal Access Token](https://github.com/settings/tokens/new?scopes=repo,read:org)
+with the "repo" and "read:org" scopes, which revup needs in order to create and modify pull
+requests. Then run
 ```sh
 revup config forge_oauth
 ```

--- a/docs/revup.md
+++ b/docs/revup.md
@@ -39,8 +39,8 @@ graphql requests to the forge.
 **--forge-oauth**
 : The oauth token that provides login credentials to the forge. Revup
 requires full repository read/write permissions in order to create
-and modify reviews. For GitHub, this is represented by the "repo" section of
-https://github.com/settings/tokens/new.
+and modify reviews. For GitHub, this requires the "repo" and "read:org" scopes at
+https://github.com/settings/tokens/new?scopes=repo,read:org.
 
 **--forge-url**
 : URL to use for the forge. Defaults to "github.com" and would only

--- a/revup/forge_utils.py
+++ b/revup/forge_utils.py
@@ -110,7 +110,7 @@ async def forge_connection(
             "Set the GITHUB_TOKEN environment variable, "
             "login with 'gh auth login', "
             "or make one at https://github.com/settings/tokens/new "
-            "(revup needs full repo permissions) "
+            "(revup needs the 'repo' and 'read:org' scopes) "
             "then set it with `revup config forge_oauth`."
         )
 


### PR DESCRIPTION
The new team reviewers functionality requires additional
read:org permissions to get the available teams.

It would be too confusing to make this optional, so require it
and update the docs.