### PR TITLE
python: Pin argcomplete to 3.7.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ REVUP_VERSION_HASH?=${shell git rev-parse --short v$(REVUP_VERSION) || echo main
 package: man
 	REVUP_VERSION_HASH=$(REVUP_VERSION_HASH) $(PYTHON) -m build --outdir $(BUILD_DIR)
 
-install:
+install: package
 	$(PYTHON) -m pip install build/revup-$(REVUP_VERSION)-py3-none-any.whl --force-reinstall
 
 upload_check:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ packages =
 python_requires = >=3.8
 install_requires =
     aiohttp
-    argcomplete
+    argcomplete==3.7.0
     async_lru
     attrs
     rich


### PR DESCRIPTION
Newer versions crash on python3.8. We can unpin when we remove
3.8 support.