### PR TITLE
git: Use git's own editor precedence via `git var GIT_EDITOR`

### DIFF
--- a/docs/revup.md
+++ b/docs/revup.md
@@ -62,8 +62,7 @@ merges. Relative-Branch cannot be used across forks.
 
 **--editor**
 : The user's preferred editor, used for various message and file
-editing. If not set, value is taken first from "git config core.editor"
-then from the GIT_EDITOR env value, then from EDITOR.
+editing. If not set, the value is taken from `git var GIT_EDITOR`.
 
 **--keep-temp, -k**
 : Occasionally, files will need to be stored to disk for various

--- a/revup/amend.py
+++ b/revup/amend.py
@@ -5,7 +5,7 @@ import re
 import shlex
 import subprocess
 from collections import defaultdict
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 from revup import git, topic_stack
 from revup.core_types import (
@@ -28,7 +28,7 @@ with '{}' will be ignored, and an empty message aborts the amend."""
 
 async def invoke_editor_for_commit_msg(
     git_ctx: git.Git,
-    editor: str,
+    editor: Optional[str],
     topic_summary: str,
     commit_msg: str,
     cache_stat: str,
@@ -39,6 +39,9 @@ async def invoke_editor_for_commit_msg(
     Stats for the commit are shown in comment lines in the editor.
     Return the final message with comment lines stripped out.
     """
+    if not editor:
+        raise RevupUsageException("Couldn't determine an editor to use, fix your git configuration")
+
     full_stat = []
     if cache_stat:
         full_stat.append(f"Changes to be committed:\n{cache_stat}")

--- a/revup/git.py
+++ b/revup/git.py
@@ -139,13 +139,18 @@ async def make_git(
             )
         return email
 
-    async def get_editor() -> str:
+    async def get_editor() -> Optional[str]:
         if editor:
             return editor
-        ret = await git_ctx.git_stdout("config", "core.editor", raiseonerror=False)
-        if not ret:
-            ret = os.environ.get("GIT_EDITOR", os.environ.get("EDITOR", "nano"))
-        return ret
+        # Defer to git's precedence order
+        ret, resolved = await git_ctx.git("var", "GIT_EDITOR", raiseonerror=False)
+        # git exits nonzero when the terminal is dumb and no editor is configured, and
+        # prints nothing if core.editor is explicitly set to empty. Either way there's no
+        # usable editor. Return None rather than raising, since most commands never open
+        # an editor; the failure is reported if and when we actually need one.
+        if ret != 0 or not resolved:
+            return None
+        return resolved
 
     async def get_gpg_sign() -> bool:
         # commit-tree (plumbing) ignores commit.gpgSign, so read it and pass -S ourselves.
@@ -161,11 +166,11 @@ async def make_git(
         git_dir,
         actual_version,
         email,
-        editor,
+        resolved_editor,
         main_exists,
         gpg_sign,
     ) = cast(
-        Tuple[str, str, str, str, str, bool, bool],
+        Tuple[str, str, str, str, Optional[str], bool, bool],
         await asyncio.gather(
             git_ctx.git_stdout("rev-parse", "--show-toplevel"),
             git_ctx.git_stdout("rev-parse", "--path-format=absolute", "--git-dir"),
@@ -193,7 +198,7 @@ async def make_git(
     git_ctx.git_dir = git_dir
     git_ctx.email = email.lower()
     git_ctx.author = git_ctx.email.split("@")[0]
-    git_ctx.editor = editor
+    git_ctx.editor = resolved_editor
     git_ctx.gpg_sign = gpg_sign
     if not main_exists:
         if main_branch in COMMON_MAIN_BRANCHES:
@@ -234,7 +239,9 @@ class Git:
 
     email: str
     author: str
-    editor: str
+
+    # Editor to use for message editing, or None if git couldn't resolve one
+    editor: Optional[str]
 
     # Whether to GPG/SSH sign commits revup creates, from git config commit.gpgSign
     gpg_sign: bool

--- a/tests/test_amend.py
+++ b/tests/test_amend.py
@@ -506,6 +506,22 @@ class TestAmendEdit:
             assert await env.get_commit_hash() == orig_hash
 
     @async_test
+    async def test_edit_no_editor_available_errors(self):
+        async with GitTestEnvironment() as env:
+            await env.commit("root", {"root.txt": "r"})
+            await env.commit("original message", {"a.txt": "a"})
+            orig_hash = await env.get_commit_hash()
+
+            # None means git couldn't resolve an editor, e.g. a dumb terminal with
+            # nothing configured. Don't guess at a fallback.
+            env.git_ctx.editor = None
+            args = make_amend_args(edit=True)
+            with pytest.raises(RevupUsageException, match="Couldn't determine an editor"):
+                await amend.main(args, env.git_ctx)
+
+            assert await env.get_commit_hash() == orig_hash
+
+    @async_test
     async def test_edit_reword_earlier_commit(self):
         async with GitTestEnvironment() as env:
             await env.commit("root", {"root.txt": "r"})


### PR DESCRIPTION
Editor resolution put core.editor ahead of $GIT_EDITOR, ignored $VISUAL
entirely, and fell back to nano. Git's actual order (see git-var(1)) is
$GIT_EDITOR, core.editor, $VISUAL, $EDITOR, then its compile-time
default, so a caller setting GIT_EDITOR to force an editor for a single
invocation was silently overridden by config.

Ask `git var GIT_EDITOR` instead of reimplementing the precedence. This
also picks up git's handling of dumb terminals, where $VISUAL is skipped
because it conventionally names a full-screen editor, and where git
refuses to fall back to its compile-time default at all.

When git reports no usable editor, error out at the point we need one
rather than guessing at nano. Resolution stays in make_git so the many
commands that never open an editor are unaffected, and the result is
typed Optional[str] so the unavailable case is visible in signatures
instead of hiding behind an empty-string sentinel.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Topic: editor
Reviewers: jerry,brian-k