### PR TITLE
build: Include revup subpackages in the distribution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,7 @@ classifiers =
 [options]
 package_dir =
      = .
-packages =
-    revup
+packages = find:
 python_requires = >=3.8
 install_requires =
     aiohttp
@@ -68,6 +67,9 @@ dev =
 
 [options.packages.find]
 where = .
+include =
+    revup
+    revup.*
 
 [options.package_data]
 revup = man1/*.1.gz


### PR DESCRIPTION
The explicit `packages` list only named `revup`, so the `revup.github`
subpackage added in c076bc0 was never shipped. Installed wheels crashed
on any forge operation with `ModuleNotFoundError: No module named
'revup.github'`. Source checkouts import it fine, which is why this went
unnoticed.

Switch to auto-discovery, scoped to `revup*` so tests and build
artifacts stay out.