### PR TITLE
github: Don't infer base and head oids from pr commit order

### DIFF
--- a/revup/forge.py
+++ b/revup/forge.py
@@ -27,10 +27,10 @@ class PrComment:
 class PrInfo:
     baseRef: str
     headRef: str
-    baseRefOid: Optional[str]
     headRefOid: Optional[str]
     body: str
     title: str
+    numCommits: int = 0
     id: str = ""
     url: str = ""
     state: str = ""

--- a/revup/github/github.py
+++ b/revup/github/github.py
@@ -29,23 +29,9 @@ PR_FRAGMENT = f"""
                 body
                 title
                 isDraft
-                baseCommit: commits(first: 1) {{
-                    nodes {{
-                        commit {{
-                            parents (first: 1) {{
-                                nodes {{
-                                    oid
-                                }}
-                            }}
-                        }}
-                    }}
-                }}
-                headCommit: commits(last: 1) {{
-                    nodes {{
-                        commit {{
-                            oid
-                        }}
-                    }}
+                headRefOid
+                commits {{
+                    totalCount
                 }}
                 reviewRequests (first: 25) {{
                     nodes {{
@@ -245,17 +231,6 @@ class GithubQuery(GraphqlQuery):
                     assignees.add(user["login"])
                     assignee_ids.add(user["id"])
 
-                headRefOid = (
-                    this_node["headCommit"]["nodes"][0]["commit"]["oid"]
-                    if this_node["headCommit"]["nodes"]
-                    else None
-                )
-                baseRefOid = (
-                    this_node["baseCommit"]["nodes"][0]["commit"]["parents"]["nodes"][0]["oid"]
-                    if this_node["baseCommit"]["nodes"]
-                    else None
-                )
-
                 comments = []
                 for c in this_node["comments"]["nodes"]:
                     comments.append(PrComment(c["body"], c["id"]))
@@ -280,8 +255,8 @@ class GithubQuery(GraphqlQuery):
                         url=this_node["url"],
                         baseRef=this_node["baseRefName"],
                         headRef=branch_name,
-                        baseRefOid=baseRefOid,
-                        headRefOid=headRefOid,
+                        headRefOid=this_node["headRefOid"],
+                        numCommits=this_node["commits"]["totalCount"],
                         body=this_node["body"],
                         title=this_node["title"],
                         reviewers=reviewers,

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -345,7 +345,6 @@ class TopicStack:
             or not self.forge
             or review.pr_info is None
             or review.pr_info.headRefOid is None
-            or review.pr_info.baseRefOid is None
             or review.base_ref is None
         ):
             return None
@@ -372,12 +371,12 @@ class TopicStack:
             if review.status == PrStatus.NEW:
                 # New PR, diff against base to show full diff
                 diff_base = review.base_ref
-            elif review.base_ref != review.pr_info.baseRefOid:
+            elif review.base_ref != review.remote_commits[0].parents[0]:
                 # Rebased review, make a virtual diff target
                 if self.last_virtual_diff_target is None:
                     self.last_virtual_diff_target = GitCommitHash(self.base_branch)
                 self.last_virtual_diff_target = await self.git_ctx.make_virtual_diff_target(
-                    GitCommitHash(review.pr_info.baseRefOid),
+                    review.remote_commits[0].parents[0],
                     GitCommitHash(review.pr_info.headRefOid),
                     review.base_ref,
                     review.new_commits[-1],
@@ -779,7 +778,7 @@ class TopicStack:
                 review.status = PrStatus.NEW
                 review.pr_info = None
 
-            if review.pr_info and (not review.pr_info.baseRefOid or not review.pr_info.headRefOid):
+            if review.pr_info and (not review.pr_info.headRefOid or not review.pr_info.numCommits):
                 logging.warning(f"Branch {review.remote_head} was merged but has no commits!")
                 review.status = PrStatus.NEW
                 review.pr_info = None
@@ -801,15 +800,16 @@ class TopicStack:
                 # This is a new pr, no need to check for rebase
                 review.is_pure_rebase = False
             else:
-                assert (
-                    review.pr_info.baseRefOid is not None and review.pr_info.headRefOid is not None
-                )
+                assert review.pr_info.headRefOid is not None
+                # Forges list a pr's commits in the order they were associated with it, which isn't
+                # topological, so we can't identify the base commit from that list. Instead walk
+                # back from the head by however many commits the pr claims to have.
                 review.remote_commits = git.parse_rev_list(
                     await self.git_ctx.rev_list(
                         review.pr_info.headRefOid,
-                        review.pr_info.baseRefOid,
                         header=True,
                         first_parent=True,
+                        max_revs=review.pr_info.numCommits,
                     )
                 )
 
@@ -1279,9 +1279,9 @@ class TopicStack:
                         )
                     review.pr_info = PrInfo(
                         baseRef=review.remote_base,
-                        baseRefOid=review.base_ref,
                         headRef=review.remote_head,
                         headRefOid=review.new_commits[-1],
+                        numCommits=len(review.new_commits),
                         body=body,
                         title=title,
                         is_draft=review.is_draft,

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -38,7 +38,7 @@ def make_pr_node(
     state: str = "OPEN",
     base_ref: str = "main",
     head_oid: str = "abc123",
-    base_oid: str = "def456",
+    num_commits: int = 1,
     is_draft: bool = False,
     reviewers: List[Dict] = None,
     team_reviewers: List[Dict] = None,
@@ -64,8 +64,8 @@ def make_pr_node(
                 "body": "body",
                 "title": "title",
                 "isDraft": is_draft,
-                "baseCommit": {"nodes": [{"commit": {"parents": {"nodes": [{"oid": base_oid}]}}}]},
-                "headCommit": {"nodes": [{"commit": {"oid": head_oid}}]},
+                "headRefOid": head_oid,
+                "commits": {"totalCount": num_commits},
                 "reviewRequests": {"nodes": review_requests},
                 "timelineItems": {"nodes": timeline_items or []},
                 "latestReviews": {"nodes": latest_reviews or []},
@@ -462,9 +462,7 @@ class TestCreatePullRequests:
         )
         gh = make_github(endpoint, fork_owner="myfork")
 
-        pr = PrInfo(
-            baseRef="main", headRef="feat1", baseRefOid=None, headRefOid=None, body="b", title="t"
-        )
+        pr = PrInfo(baseRef="main", headRef="feat1", headRefOid=None, body="b", title="t")
         asyncio.run(gh.create_pull_requests("R_1", [pr]))
 
         _, kwargs = endpoint.graphql.call_args
@@ -480,9 +478,7 @@ class TestCreatePullRequests:
         )
         gh = make_github(endpoint, fork_owner="owner")
 
-        pr = PrInfo(
-            baseRef="main", headRef="feat1", baseRefOid=None, headRefOid=None, body="b", title="t"
-        )
+        pr = PrInfo(baseRef="main", headRef="feat1", headRefOid=None, body="b", title="t")
         asyncio.run(gh.create_pull_requests("R_1", [pr]))
 
         _, kwargs = endpoint.graphql.call_args
@@ -498,7 +494,6 @@ class TestCreatePullRequests:
         pr = PrInfo(
             baseRef="main",
             headRef="feat1",
-            baseRefOid=None,
             headRefOid=None,
             body="b",
             title="t",
@@ -537,9 +532,7 @@ class TestCreatePullRequests:
         endpoint.graphql = mock_graphql
         gh = make_github(endpoint)
 
-        pr = PrInfo(
-            baseRef="main", headRef="feat1", baseRefOid=None, headRefOid=None, body="b", title="t"
-        )
+        pr = PrInfo(baseRef="main", headRef="feat1", headRefOid=None, body="b", title="t")
         asyncio.run(gh.create_pull_requests("R_1", [pr]))
 
         assert pr.id == "PR_existing"
@@ -565,7 +558,6 @@ class TestCreatePullRequests:
             PrInfo(
                 baseRef="main",
                 headRef=f"f{i}",
-                baseRefOid=None,
                 headRefOid=None,
                 body="b",
                 title=f"t{i}",

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -904,8 +904,8 @@ def make_pr_info(review, base_branch="main"):
     return PrInfo(
         baseRef=base_branch,
         headRef=review.remote_head,
-        baseRefOid=review.base_ref,
         headRefOid=review.new_commits[-1],
+        numCommits=len(review.new_commits),
         body="",
         title="",
         state="OPEN",
@@ -940,7 +940,7 @@ class TestRebaseDetection:
             first = await run_upload_pipeline(env)
             first_review = first.topics["alpha"].reviews["origin/main"]
             remote_head = first_review.new_commits[-1]
-            remote_base = first_review.base_ref
+            remote_num_commits = len(first_review.new_commits)
 
             # Reword the commit (same diff, different message)
             await env.git_ctx.git("commit", "--amend", "-m", "new title\n\nTopic: alpha")
@@ -951,8 +951,8 @@ class TestRebaseDetection:
             review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=review.remote_head,
-                baseRefOid=remote_base,
                 headRefOid=remote_head,
+                numCommits=remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -973,7 +973,7 @@ class TestRebaseDetection:
             first = await run_upload_pipeline(env)
             first_review = first.topics["alpha"].reviews["origin/main"]
             remote_head = first_review.new_commits[-1]
-            remote_base = first_review.base_ref
+            remote_num_commits = len(first_review.new_commits)
 
             # Amend with different content
             await env.stage_file("a.txt", "v2")
@@ -984,8 +984,8 @@ class TestRebaseDetection:
             review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=review.remote_head,
-                baseRefOid=remote_base,
                 headRefOid=remote_head,
+                numCommits=remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -1007,7 +1007,7 @@ class TestRebaseDetection:
             first = await run_upload_pipeline(env)
             first_review = first.topics["alpha"].reviews["origin/main"]
             remote_head = first_review.new_commits[-1]
-            remote_base = first_review.base_ref
+            remote_num_commits = len(first_review.new_commits)
 
             # Advance origin/main independently, then rebase local onto it
             await env.git_ctx.git("checkout", root)
@@ -1022,8 +1022,8 @@ class TestRebaseDetection:
             review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=review.remote_head,
-                baseRefOid=remote_base,
                 headRefOid=remote_head,
+                numCommits=remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -1045,7 +1045,7 @@ class TestRebaseDetection:
             first = await run_upload_pipeline(env)
             first_review = first.topics["alpha"].reviews["origin/main"]
             remote_head = first_review.new_commits[-1]
-            remote_base = first_review.base_ref
+            remote_num_commits = len(first_review.new_commits)
 
             # Advance and rebase
             await env.git_ctx.git("checkout", root)
@@ -1060,8 +1060,8 @@ class TestRebaseDetection:
             review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=review.remote_head,
-                baseRefOid=remote_base,
                 headRefOid=remote_head,
+                numCommits=remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -1082,7 +1082,7 @@ class TestRebaseDetection:
             first = await run_upload_pipeline(env)
             first_review = first.topics["alpha"].reviews["origin/main"]
             remote_head = first_review.new_commits[-1]
-            remote_base = first_review.base_ref
+            remote_num_commits = len(first_review.new_commits)
 
             # Amend with new content
             await env.stage_file("a.txt", "v2")
@@ -1093,8 +1093,8 @@ class TestRebaseDetection:
             review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=review.remote_head,
-                baseRefOid=remote_base,
                 headRefOid=remote_head,
+                numCommits=remote_num_commits,
                 body="",
                 title="",
                 state="MERGED",
@@ -1118,9 +1118,9 @@ class TestRebaseDetection:
             parent_review = first.topics["parent"].reviews["origin/main"]
             child_review = first.topics["child"].reviews["origin/main"]
             parent_remote_head = parent_review.new_commits[-1]
-            parent_remote_base = parent_review.base_ref
+            parent_remote_num_commits = len(parent_review.new_commits)
             child_remote_head = child_review.new_commits[-1]
-            child_remote_base = child_review.base_ref
+            child_remote_num_commits = len(child_review.new_commits)
 
             # Advance origin/main independently, then rebase local onto it
             await env.git_ctx.git("checkout", root)
@@ -1142,8 +1142,8 @@ class TestRebaseDetection:
             p_review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=p_review.remote_head,
-                baseRefOid=parent_remote_base,
                 headRefOid=parent_remote_head,
+                numCommits=parent_remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -1151,8 +1151,8 @@ class TestRebaseDetection:
             c_review.pr_info = PrInfo(
                 baseRef=p_review.remote_head,
                 headRef=c_review.remote_head,
-                baseRefOid=child_remote_base,
                 headRefOid=child_remote_head,
+                numCommits=child_remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -1176,7 +1176,7 @@ class TestRebaseDetection:
             first = await run_upload_pipeline(env)
             first_review = first.topics["alpha"].reviews["origin/main"]
             remote_head = first_review.new_commits[-1]
-            remote_base = first_review.base_ref
+            remote_num_commits = len(first_review.new_commits)
 
             # Amend only the second commit (HEAD) with new content
             await env.stage_file("b.txt", "b_new")
@@ -1187,8 +1187,8 @@ class TestRebaseDetection:
             review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=review.remote_head,
-                baseRefOid=remote_base,
                 headRefOid=remote_head,
+                numCommits=remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -1209,7 +1209,7 @@ class TestRebaseDetection:
             first = await run_upload_pipeline(env)
             first_review = first.topics["alpha"].reviews["origin/main"]
             remote_head = first_review.new_commits[-1]
-            remote_base = first_review.base_ref
+            remote_num_commits = len(first_review.new_commits)
 
             # Add a second commit to the same topic
             await env.commit("c2\n\nTopic: alpha", {"b.txt": "b"})
@@ -1219,8 +1219,8 @@ class TestRebaseDetection:
             review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=review.remote_head,
-                baseRefOid=remote_base,
                 headRefOid=remote_head,
+                numCommits=remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -1254,7 +1254,7 @@ class TestRebaseDetection:
             first = await run_upload_pipeline(env)
             first_review = first.topics["alpha"].reviews["origin/main"]
             remote_head = first_review.new_commits[-1]
-            remote_base = first_review.base_ref
+            remote_num_commits = len(first_review.new_commits)
 
             # Second run with the same commits — should detect as rebase
             topics = await run_upload_pipeline(env)
@@ -1262,8 +1262,8 @@ class TestRebaseDetection:
             review.pr_info = PrInfo(
                 baseRef="main",
                 headRef=review.remote_head,
-                baseRefOid=remote_base,
                 headRefOid=remote_head,
+                numCommits=remote_num_commits,
                 body="",
                 title="",
                 state="OPEN",
@@ -1272,6 +1272,69 @@ class TestRebaseDetection:
             await topics.mark_rebases(skip_rebase=True)
 
             assert review.is_pure_rebase
+
+    @async_test
+    async def test_base_derived_by_walking_back_from_head(self):
+        """A branch holding more commits than its topic must still resolve a base.
+
+        Forges list a pr's commits in association order, not topological order, so the base can
+        only come from walking back numCommits from the head.
+        """
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            root = await env.get_commit_hash()
+            await env.commit("a\n\nTopic: alpha", {"a.txt": "a"})
+            await env.commit("b\n\nTopic: beta\nRelative: alpha", {"b.txt": "b"})
+            await env.commit("c\n\nTopic: gamma\nRelative: beta", {"c.txt": "c"})
+
+            first = await run_upload_pipeline(env)
+            alpha_review = first.topics["alpha"].reviews["origin/main"]
+            beta_review = first.topics["beta"].reviews["origin/main"]
+            gamma_review = first.topics["gamma"].reviews["origin/main"]
+            beta_remote_head = beta_review.new_commits[-1]
+            # Beta's branch is stacked on alpha's, so once alpha is gone the forge counts both.
+            beta_num_commits = len(alpha_review.new_commits) + len(beta_review.new_commits)
+            gamma_remote_head = gamma_review.new_commits[-1]
+            gamma_num_commits = len(gamma_review.new_commits)
+
+            # Drop alpha from the local stack, as if it had merged.
+            await env.git_ctx.git("reset", "--hard", root)
+            await env.commit("b\n\nTopic: beta\nRelative: alpha", {"b.txt": "b"})
+            await env.commit("c\n\nTopic: gamma\nRelative: beta", {"c.txt": "c"})
+
+            topics = await run_upload_pipeline(env)
+            b_review = topics.topics["beta"].reviews["origin/main"]
+            g_review = topics.topics["gamma"].reviews["origin/main"]
+            b_review.pr_info = PrInfo(
+                baseRef="main",
+                headRef=b_review.remote_head,
+                headRefOid=beta_remote_head,
+                numCommits=beta_num_commits,
+                body="",
+                title="",
+                state="OPEN",
+            )
+            g_review.pr_info = PrInfo(
+                baseRef=b_review.remote_head,
+                headRef=g_review.remote_head,
+                headRefOid=gamma_remote_head,
+                numCommits=gamma_num_commits,
+                body="",
+                title="",
+                state="OPEN",
+            )
+
+            await topics.mark_rebases(skip_rebase=True)
+
+            assert [c.commit_id for c in b_review.remote_commits] == [
+                await env.get_commit_hash(f"{beta_remote_head}~1"),
+                beta_remote_head,
+            ]
+            assert b_review.remote_commits[0].parents[0] == root
+            assert not b_review.is_pure_rebase
+            # Gamma being a rebase is what makes it read beta's remote commits.
+            assert g_review.is_pure_rebase
+            assert g_review.remote_commits[0].parents[0] == b_review.remote_commits[-1].commit_id
 
 
 class TestSkipEmptyFirstCommit:


### PR DESCRIPTION
A forge lists a pr's commits in the order they were associated with it,
not in topological order. When a pr's base is retargeted, newly exposed
ancestors get appended after the commits already on the pr, so
commits(first: 1) is not the base-most commit and commits(last: 1) is
not the tip.

Seen on a pr stacked on a topic branch that then merged: GitHub's
automatic base change retargeted it to master, growing its commit list
from 1 to 3 as [tip, base-most, middle]. baseRefOid and headRefOid both
resolved to the middle commit, so rev-list produced no remote commits at
all, and a relative topic indexing into that empty list crashed upload.

Ask for headRefOid directly and walk back the number of commits the pr
reports, which needs no ordering assumption and costs fewer nodes. The
base commit is then whatever that walk lands on.