### PR TITLE
upload: Mark drafts with a Draft: tag instead of a magic label

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,14 @@ Revup can also add reviewers, assignees, and labels to pull requests. Add the ap
 ```
 Reviewers: alice, bob, myorg/backend-team
 Assignees: eve
-Labels: bug, feature, draft
+Labels: bug, feature
+Draft: true
 ```
 
 Github usernames can be abbreviated and will match the shortest name with the given prefix.
 Teams are specified as `org/team-slug` and can be used as reviewers (Github does not support teams as assignees).
 
-Labels must match exactly. The `draft` label is special and will make a pull request a draft if present and unmake draft if removed.
+Labels must match exactly. `Draft: true` makes a pull request a draft, and `Draft: false` or removing the tag unmakes it.
 
 ## Working on other branches
 

--- a/docs/upload.md
+++ b/docs/upload.md
@@ -68,9 +68,11 @@ for reviewers, except that Github does not support teams as assignees so
 
 **Labels:**
 : Specifies labels that will be added on github. Labels must match the label
-name in github exactly. If a label cannot be found a warning is printed. The
-label "draft" is special and instead of showing up in labels, will cause the
-PR to either be marked or unmarked as a draft.
+name in github exactly. If a label cannot be found a warning is printed.
+
+**Draft:**
+: Accepts "true" or "false" and marks or unmarks the PR as a draft. PRs are
+not drafts if this tag is omitted.
 
 **Uploader:**
 : Optionally specifies a custom uploader name that will be used instead of the

--- a/revup/restack.py
+++ b/revup/restack.py
@@ -14,6 +14,7 @@ from revup.topic_stack import (
     TAG_ASSIGNEE,
     TAG_BRANCH,
     TAG_BRANCH_FORMAT,
+    TAG_DRAFT,
     TAG_LABEL,
     TAG_RELATIVE,
     TAG_RELATIVE_BRANCH,
@@ -36,6 +37,7 @@ TAG_ORDER = [
     TAG_UPLOADER,
     TAG_UPDATE_PR_BODY,
     TAG_BRANCH_FORMAT,
+    TAG_DRAFT,
 ]
 
 

--- a/revup/topic_stack.py
+++ b/revup/topic_stack.py
@@ -69,6 +69,7 @@ TAG_RELATIVE_BRANCH = "relative-branch"
 TAG_UPLOADER = "uploader"
 TAG_UPDATE_PR_BODY = "update-pr-body"
 TAG_BRANCH_FORMAT = "branch-format"
+TAG_DRAFT = "draft"
 VALID_TAGS = {
     TAG_BRANCH,
     TAG_LABEL,
@@ -80,12 +81,26 @@ VALID_TAGS = {
     TAG_UPLOADER,
     TAG_UPDATE_PR_BODY,
     TAG_BRANCH_FORMAT,
+    TAG_DRAFT,
 }
 
 RE_COMMIT_LABEL = re.compile(r"^(?P<label1>[a-zA-Z\-_0-9]+):.*|^\[(?P<label2>[a-zA-Z\-_0-9]+)\].*")
 
 PATCHSETS_FIRST_LINE = "| # | head | base | diff | date | summary |\r\n| - | - | - | - | - | - |"
 REVIEW_GRAPH_FIRST_LINE = "Reviews in this chain:\r\n"
+
+
+def get_bool_tag(tags: Dict[str, Set[str]], tag: str, default: bool = False) -> bool:
+    """
+    Return the value of a tag that accepts the same boolean values as config options,
+    or the default if the tag isn't given.
+    """
+    if tag not in tags:
+        return default
+    value = min(tags[tag]).lower()
+    if len(tags[tag]) > 1 or value not in ("true", "false"):
+        raise RevupUsageException(f"Invalid tags for {tag}: {tags[tag]}")
+    return value == "true"
 
 
 def add_tags(original: Dict[str, Set[str]], new: Dict[str, Set[str]]) -> None:
@@ -528,13 +543,9 @@ class TopicStack:
             if len(topic.tags[TAG_UPLOADER]) > 1:
                 raise RevupUsageException(f"Can't specify more than one uploader for topic {name}!")
 
-            if TAG_UPDATE_PR_BODY in topic.tags:
-                if len(topic.tags[TAG_UPDATE_PR_BODY]) > 1 or min(
-                    topic.tags[TAG_UPDATE_PR_BODY]
-                ).lower() not in {"true", "false"}:
-                    raise RevupUsageException(
-                        f"Invalid tags for update-pr-body: {topic.tags[TAG_UPDATE_PR_BODY]}"
-                    )
+            # Validate boolean tags now so that errors are reported before uploading
+            for bool_tag in (TAG_UPDATE_PR_BODY, TAG_DRAFT):
+                get_bool_tag(topic.tags, bool_tag)
 
             if TAG_BRANCH_FORMAT in topic.tags:
                 if (
@@ -720,10 +731,7 @@ class TopicStack:
 
                 topic.reviews[branch] = review
 
-                review.is_draft = "draft" in topic.tags[TAG_LABEL]
-
-            # Don't add draft as a label since its instead used to mark a pr as a draft
-            topic.tags[TAG_LABEL].discard("draft")
+                review.is_draft = get_bool_tag(topic.tags, TAG_DRAFT)
 
     async def mark_rebases(self, skip_rebase: bool) -> None:
         """
@@ -1375,10 +1383,7 @@ class TopicStack:
                         assignee_logins -= removed
                         assignee_ids -= review.pr_info.removed_assignee_ids
 
-                if TAG_UPDATE_PR_BODY in topic.tags:
-                    update_pr_body = min(topic.tags[TAG_UPDATE_PR_BODY]).lower() == "true"
-                else:
-                    update_pr_body = update_pr_body_arg
+                update_pr_body = get_bool_tag(topic.tags, TAG_UPDATE_PR_BODY, update_pr_body_arg)
 
                 if review.pr_info.baseRef != review.remote_base:
                     review.pr_update.baseRef = review.remote_base

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -467,18 +467,33 @@ class TestUploadBranchFormat:
                 await run_upload_pipeline(env)
 
 
-class TestUploadDraftLabel:
+class TestUploadDraftTag:
     @async_test
-    async def test_draft_label_marks_review_as_draft(self):
+    async def test_draft_tag_marks_review_as_draft(self):
         async with GitTestEnvironment() as env:
             await setup_repo(env)
-            await env.commit("feat\n\nTopic: alpha\nLabel: draft", {"a.txt": "a"})
+            await env.commit("feat\n\nTopic: alpha\nDraft: TRUE", {"a.txt": "a"})
 
             topics = await run_upload_pipeline(env)
-            review = topics.topics["alpha"].reviews["origin/main"]
-            assert review.is_draft is True
-            # "draft" is removed from the label set
-            assert "draft" not in topics.topics["alpha"].tags["label"]
+            assert topics.topics["alpha"].reviews["origin/main"].is_draft is True
+
+    @async_test
+    async def test_draft_false_doesnt_mark_review_as_draft(self):
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("feat\n\nTopic: alpha\nDraft: false", {"a.txt": "a"})
+
+            topics = await run_upload_pipeline(env)
+            assert topics.topics["alpha"].reviews["origin/main"].is_draft is False
+
+    @async_test
+    async def test_invalid_draft_tag_raises(self):
+        async with GitTestEnvironment() as env:
+            await setup_repo(env)
+            await env.commit("feat\n\nTopic: alpha\nDraft: maybe", {"a.txt": "a"})
+
+            with pytest.raises(RevupUsageException):
+                await run_upload_pipeline(env)
 
 
 class TestUploadAutoAddUsers:
@@ -1705,11 +1720,11 @@ class TestForgeLabels:
             assert "label_main" in update.label_ids
 
     @async_test
-    async def test_draft_label_creates_draft_pr(self):
+    async def test_draft_tag_creates_draft_pr(self):
         async with GitTestEnvironment() as env:
             await setup_repo(env)
             forge = FakeForge()
-            await env.commit("feat\n\nTopic: alpha\nLabel: draft", {"a.txt": "a"})
+            await env.commit("feat\n\nTopic: alpha\nDraft: true", {"a.txt": "a"})
 
             await full_upload_pipeline(env, forge)
 


### PR DESCRIPTION
"Labels: draft" was overloaded: the label named draft never made it to
github and instead toggled the pr's draft state, so a repo that has a
real label by that name couldn't apply it.

Use a dedicated "Draft:" tag taking the same true/false values that
config options take. Absent tag means not a draft, so an existing
"Draft: false" still clears the flag on a pr that was a draft before.

The true/false parsing and validation is now shared with Update-Pr-Body
via get_bool_tag, and both are validated up front so a bad value is
reported before anything gets uploaded.